### PR TITLE
Zmiana kolumny PIN w tabeli customers

### DIFF
--- a/lib/upgradedb/mysql.2012032901.php
+++ b/lib/upgradedb/mysql.2012032901.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * LMS version 1.11-cvs
+ *
+ *  (C) Copyright 2001-2012 LMS Developers
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ */
+
+$DB->BeginTrans();
+$DB->Execute("ALTER TABLE customers CHANGE pin pin VARCHAR( 6 ) NOT NULL DEFAULT '0'");
+$DB->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2012032901', 'dbversion'));
+$DB->CommitTrans();
+
+?>


### PR DESCRIPTION
Zmienia kolumne PIN z INT na VARCHAR w tabeli customers, ponieważ jeśli klient wpisze PIN: 0234, to przejdzie przez walidacje (PIN >= 4), ale w bazie zapisze się tylko 234, bez 0 na początku.
