### PR TITLE
Small fix for new PHP version

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -2,6 +2,7 @@ $Id: ChangeLog,v 1.1637 2012/02/18 23:12:00 chilek Exp $
 
 version ? (????-??-??):
 
+  - small fix for new PHP version [red]
   - Fixed nodes list in Userpanel [alec]
   - lmsd/ewx-pt: Fixed issues on nodes deletion [alec]
   - lmsd/ewx-stm-channels: Fixed issues on nodes deletion, improved performance [alec]

--- a/lib/dns.php
+++ b/lib/dns.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/auth/modinfo.php
+++ b/modules/auth/modinfo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/core/actions/modinfo-sample.php
+++ b/modules/core/actions/modinfo-sample.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/core/modinfo.php
+++ b/modules/core/modinfo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/mailing/modinfo.php
+++ b/modules/mailing/modinfo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/modinfo-sample.php
+++ b/modules/modinfo-sample.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/traffic/modinfo.php
+++ b/modules/traffic/modinfo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs

--- a/modules/users/modinfo.php
+++ b/modules/users/modinfo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*
  * LMS version 1.11-cvs


### PR DESCRIPTION
Od któreś tam wersji, PHP olewa interpretowanie pliku jeśli się nie zaczyna od "<?php", więc "<?" psuło.
