### PR TITLE
fix validation data in domains for DKIM

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -112,6 +112,7 @@ version ? (????-??-??):
   - changed pin field type from int to varchar(6) [red]
   - liability reports are consistent with invoice/cash issues [chilan]
   - small fix for new PHP version [red]
+  - fix validation data in domains for DKIM [red]
 
 version 1.11.13 Dira (2011-04-07)
 

--- a/lib/dns.php
+++ b/lib/dns.php
@@ -71,7 +71,7 @@ function check_hostname_fqdn($hostname, $wildcard=false, $dns_strict_tld_check=f
 			}
                         $first = 1;
                 } else {
-                        if (!preg_match('/^[a-zA-Z0-9-\/]+$/',$hostname_label)) {
+                        if (!preg_match('/^[a-zA-Z0-9-\/_]+$/',$hostname_label)) {
 				return trans('You have invalid characters in your hostname!');
 			}
                 }


### PR DESCRIPTION
Przykładowy rekord: "mail._domainkey.example.com". To "_domainkey" zawsze występuje.
