### PR TITLE
możliwość ustawienia ID klienta przy dodawaniu nowego.

### DIFF
--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -478,14 +478,15 @@ class LMS {
 	}
 
 	function CustomerAdd($customeradd) {
-		if ($this->DB->Execute('INSERT INTO customers (name, lastname, type,
+		if ($this->DB->Execute('INSERT INTO customers (id, name, lastname, type,
 				    address, zip, city, countryid, email, ten, ssn, status, creationdate,
 				    post_name, post_address, post_zip, post_city, post_countryid,
 				    creatorid, info, notes, message, pin, regon, rbe,
 				    icn, cutoffstop, consentdate, einvoice, divisionid, paytime, paytype,
 				    invoicenotice, mailingnotice)
-				    VALUES (?, UPPER(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?NOW?,
-				    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', array(lms_ucwords($customeradd['name']),
+				    VALUES (?, ?, UPPER(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?NOW?,
+				    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', array($customeradd['id'],
+				    		lms_ucwords($customeradd['name']),
 						$customeradd['lastname'],
 						empty($customeradd['type']) ? 0 : 1,
 						$customeradd['address'],

--- a/lib/locale/pl/strings.php
+++ b/lib/locale/pl/strings.php
@@ -441,6 +441,7 @@ $_LANG['Enter creditor name'] = 'Wprowadź nazwę wierzyciela';
 $_LANG['Enter customer address'] = 'Wprowadź adres klienta';
 $_LANG['Enter customer city'] = 'Wprowadź miasto klienta';
 $_LANG['Enter customer e-mail address (optional)'] = 'Wprowadź adres e-mail klienta (opcjonalnie)';
+$_LANG['Enter customer id. WARNING! Changing this number can be DANGEROUS! (leave this field empty to obtain next number)'] = 'Wprowadź id klienta. UWAGA! Zmiana tego numeru może być NIEBEZPIECZNA! (pozostaw to pole puste aby uzyskać kolejny numer)';
 $_LANG['Enter customer name'] = 'Wprowadź imię klienta';
 $_LANG['Enter customer Social Security Number (optional)'] = 'Wprowadź numer PESEL klienta (opcjonalnie)';
 $_LANG['Enter customer last name or company name'] = 'Wprowadź nazwisko lub nazwę firmy';

--- a/templates/customeradd.html
+++ b/templates/customeradd.html
@@ -46,6 +46,16 @@
 		<TD class="fall" width="100%" colspan="2">
 			<TABLE>
 				<TR>
+                                        <TD>
+                                                <B>{trans("ID:")}</B>
+                                        </TD>
+                                        <TD>&nbsp;</TD>
+                                        </TD>
+                                        <TD>
+                                                <INPUT TYPE="TEXT" NAME="customeradd[id]" VALUE="{$customeradd.id}" SIZE="5" {tip text="Enter customer id. WARNING! Changing this number can be DANGEROUS! (leave this field empty to obtain next number)" trigger="id" bold=1}>
+                                        </TD>
+                                </TR>
+				<TR>
 					<TD>
 						<B>{trans("Name/Surname:")}</B>
 					</TD>

--- a/templates/customerinfobox.html
+++ b/templates/customerinfobox.html
@@ -48,18 +48,18 @@
 			<IMG SRC="img/print.gif" ALT="">
 		</TD>
 		<TD WIDTH="99%">
-                       <B>Dane klienta:</B><BR>
-                       <TABLE CELLPADDING="5">
-                       <TR>
-                       <TD CLASS="fall lucid">
-			{$customerinfo.address}<BR>
-			{$customerinfo.zip} {$customerinfo.city}
-			{if $customerinfo.cstate}<BR>{$customerinfo.cstate}{/if}
-			{if $customerinfo.country}<BR>{t}{$customerinfo.country}{/t}{/if}
-                       </TD>
-                       </TR>
-                       </TABLE>
-</TD>
+            		<B>{trans("Customer address:")}</B><BR>
+			    <TABLE CELLPADDING="5">
+                    		<TR>
+                    		    <TD CLASS="fall lucid">
+					{$customerinfo.address}<BR>
+					{$customerinfo.zip} {$customerinfo.city}
+					{if $customerinfo.cstate}<BR>{$customerinfo.cstate}{/if}
+					{if $customerinfo.country}<BR>{t}{$customerinfo.country}{/t}{/if}
+				    </TD>
+                    		</TR>
+			    </TABLE>
+		</TD>
 	</TR>
 {if $customerinfo.post_name neq "" || $customerinfo.post_address neq ""}
 	<TR CLASS="LIGHT">
@@ -67,18 +67,18 @@
 			<IMG SRC="img/post.gif" ALT="">
 		</TD>
 		<TD WIDTH="99%">
-                       <B>Adres korespondencyjny:</B><BR>
-                       <TABLE CELLPADDING="5">
-                       <TR>
-                       <TD CLASS="fall lucid">
-			{if $customerinfo.post_name neq ""}{$customerinfo.post_name}{/if}
-			{if $customerinfo.post_address neq ""}<BR>{$customerinfo.post_address}{/if}
-			{$customerinfo.post_zip} {$customerinfo.post_city}
-			{if $customerinfo.post_cstate}<BR>{$customerinfo.post_cstate}{/if}
-			{if $customerinfo.post_country}<BR>{t}{$customerinfo.post_country}{/t}{/if}
-                       </TD>
-                       </TR>
-                       </TABLE>
+            		<B>{trans("Postal address:")}</B><BR>
+            		    <TABLE CELLPADDING="5">
+            			<TR>
+        			    <TD CLASS="fall lucid">
+					{if $customerinfo.post_name neq ""}{$customerinfo.post_name}{/if}
+					{if $customerinfo.post_address neq ""}<BR>{$customerinfo.post_address}{/if}
+					{$customerinfo.post_zip} {$customerinfo.post_city}
+					{if $customerinfo.post_cstate}<BR>{$customerinfo.post_cstate}{/if}
+					{if $customerinfo.post_country}<BR>{t}{$customerinfo.post_country}{/t}{/if}
+        			    </TD>
+        			</TR>
+        		    </TABLE>
                </TD>
        </TR>
 {/if}
@@ -88,14 +88,14 @@
                        <IMG SRC="img/home.gif" ALT="">
                </TD>
                <TD WIDTH="99%">
-                       <B>Adres instalacji:</B><BR>
-                       <TABLE CELLPADDING="5">
-                       <TR>
-                       <TD CLASS="fall lucid">
-                       {$customerinfo.inst_address}<BR>
-                       </TD>
-                       </TR>
-                       </TABLE>
+                	<B>{trans("Installation address:")}</B><BR>
+            		<TABLE CELLPADDING="5">
+            		    <TR>
+        			<TD CLASS="fall lucid">
+        			    {$customerinfo.inst_address}<BR>
+        			</TD>
+        		    </TR>
+        		</TABLE>
 		</TD>
 	</TR>
 {/if}

--- a/templates/customerinfobox.html
+++ b/templates/customerinfobox.html
@@ -44,15 +44,22 @@
 		</TD>
 	</TR>
 	<TR CLASS="LIGHT">
-		<TD WIDTH="1%" style="vertical-align: top">
-			<IMG SRC="img/home.gif" ALT="">
+		<TD WIDTH="1%">
+			<IMG SRC="img/print.gif" ALT="">
 		</TD>
 		<TD WIDTH="99%">
+                       <B>Dane klienta:</B><BR>
+                       <TABLE CELLPADDING="5">
+                       <TR>
+                       <TD CLASS="fall lucid">
 			{$customerinfo.address}<BR>
 			{$customerinfo.zip} {$customerinfo.city}
 			{if $customerinfo.cstate}<BR>{$customerinfo.cstate}{/if}
 			{if $customerinfo.country}<BR>{t}{$customerinfo.country}{/t}{/if}
-		</TD>
+                       </TD>
+                       </TR>
+                       </TABLE>
+</TD>
 	</TR>
 {if $customerinfo.post_name neq "" || $customerinfo.post_address neq ""}
 	<TR CLASS="LIGHT">
@@ -60,11 +67,35 @@
 			<IMG SRC="img/post.gif" ALT="">
 		</TD>
 		<TD WIDTH="99%">
+                       <B>Adres korespondencyjny:</B><BR>
+                       <TABLE CELLPADDING="5">
+                       <TR>
+                       <TD CLASS="fall lucid">
 			{if $customerinfo.post_name neq ""}{$customerinfo.post_name}{/if}
 			{if $customerinfo.post_address neq ""}<BR>{$customerinfo.post_address}{/if}
 			{$customerinfo.post_zip} {$customerinfo.post_city}
 			{if $customerinfo.post_cstate}<BR>{$customerinfo.post_cstate}{/if}
 			{if $customerinfo.post_country}<BR>{t}{$customerinfo.post_country}{/t}{/if}
+                       </TD>
+                       </TR>
+                       </TABLE>
+               </TD>
+       </TR>
+{/if}
+{if $customerinfo.inst_address neq ""}
+       <TR CLASS="LIGHT">
+               <TD WIDTH="1%">
+                       <IMG SRC="img/home.gif" ALT="">
+               </TD>
+               <TD WIDTH="99%">
+                       <B>Adres instalacji:</B><BR>
+                       <TABLE CELLPADDING="5">
+                       <TR>
+                       <TD CLASS="fall lucid">
+                       {$customerinfo.inst_address}<BR>
+                       </TD>
+                       </TR>
+                       </TABLE>
 		</TD>
 	</TR>
 {/if}


### PR DESCRIPTION
Potrzebowałem takiego rozwiązania to przy okazji udostępniam.
Funkcjonalność taka jak przy dodawaniu nowych faktur. 

Mi przydało się do przeklepania klientów z innej bazy tak by zachować im ich numery ID.

![customeradd_id](https://f.cloud.github.com/assets/1541656/14431/bc853644-4641-11e2-9860-e620637e8116.JPG)
