### PR TITLE
Drobna poprawka parsera importu operacji bankowych

### DIFF
--- a/modules/cashimportparser.php
+++ b/modules/cashimportparser.php
@@ -99,7 +99,7 @@ elseif(isset($_FILES['file']) && is_uploaded_file($_FILES['file']['tmp_name']) &
 					$from = mktime(0,0,0, $invmonth, 1, $invyear);
 					$to = mktime(0,0,0, !empty($pattern['pinvoice_month']) && $pattern['pinvoice_month'] > 0 ? $invmonth + 1 : 13, 1, $invyear);
 					$id = $DB->GetOne('SELECT customerid FROM documents 
-							WHERE number=? AND cdate>? AND cdate<? AND type IN (?,?)', 
+							WHERE number=? AND cdate>=? AND cdate<? AND type IN (?,?)', 
 							array($invid, $from, $to, DOC_INVOICE, DOC_CNOTE));
 				}
 			}


### PR DESCRIPTION
W przypadku generowania faktur z opcją fakedate=YYYY/MM/DD czas ustawiany jest domyślnie na 00:00. Zmiana powoduje poprawne poszukiwanie ID klienta po numerze faktury w tytule wpłaty w obrębie danego miesiąca. Do tej pory były wyszukiwane faktury od YYYY/MM/01 00:01.
