### PR TITLE
Drobna ułatwienie na liście importowanych operacji bankowych

### DIFF
--- a/templates/cashimport.html
+++ b/templates/cashimport.html
@@ -75,6 +75,7 @@
 		    </TD>
 		    <TD ALIGN="RIGHT" CLASS="fright" COLSPAN="2" NOWRAP>
 			{if !$item.customerid}
+			<INPUT TYPE="text" SIZE="6" NAME="customer[{$item.id}]" VALUE="">
 			<SELECT NAME="customer[{$item.id}]" {tip text="Select customer" trigger=$item.id}>
 				<OPTION VALUE="0">{trans("- select customer -")}</OPTION>
 				{foreach from=$customerlist item=customer}


### PR DESCRIPTION
Zmiana dodaje dodatkowe pole w którym można ręcznie (i szybciej niż z rozwijanej listy) wpisać ID klienta, które można "wysnuć ocznie" z tytułu przelewu. Jako, że pole jest przed listą rozwijaną powtórzenie customerid nie stanowi problemu. Osobiście u siebie usunąłem w ogóle rozwijaną listę klientów ze względu na zżeranie zasobów i jako zbędny ficzer w większości przypadków (uciążliwy). Będę wdzięczny za przyjęcie przez Szanownych Developerów wniosku o "zaopcjonowanie" wyboru w UI, czy ma być pole czy rozwijana lista w sekcji [finances] i polu np. [cashimport_selectlist] [0/1] :)