### PR TITLE
Update modules/invoice_tcpdf.inc.php (poprawione)

### DIFF
--- a/modules/invoice_tcpdf.inc.php
+++ b/modules/invoice_tcpdf.inc.php
@@ -376,6 +376,8 @@ function invoice_buyer() {
 	$buyer .= $invoice['zip'] . ' ' . $invoice['city'] . '<br>';
 	if ($invoice['ten'])
 		$buyer .= trans('TEN') . ': ' . $invoice['ten'] . '<br>';
+	else
+		$buyer .= trans('SSN') . ': ' . $invoice['ssn'] . '<br>';
 	$pdf->SetFont('arial', '', 10);
 	$pdf->writeHTMLCell(80, '', '', '', $buyer, 0, 1, 0, true, 'L');
 


### PR DESCRIPTION
Po zmianach dotyczących identyfikacji podatników oraz faktur uproszczonych (od 1 stycznia 2013 r.) podanie numeru PESEL na fakturze daje 100% pewność, co do kompletności danych (w razie nawet niekompletnych danych klienta). Wg. nowych przepisów wystarczy na fakturze uproszczonej podać jedynie numer PESEL kupującego. Być może warto wprowadzić opcję faktury uproszczonej do LMSa (limit kwoty to 450 zł z VAT)?
