### PR TITLE
Fix xajax for PHP 5.4

### DIFF
--- a/lib/xajax/xajax_core/xajaxPluginManager.inc.php
+++ b/lib/xajax/xajax_core/xajaxPluginManager.inc.php
@@ -283,7 +283,7 @@ class xajaxPluginManager
 		foreach ($aKeys as $sKey)
 		{
 			$objPlugin =& $this->aRegistrars[$sKey];
-			$mResult =& $objPlugin->register($aArgs);
+			$mResult = $objPlugin->register($aArgs);
 			if (is_a($mResult, 'xajaxRequest'))
 				return $mResult;
 			if (is_array($mResult))


### PR DESCRIPTION
Wywalało błąd:
Strict Standards: Only variables should be assigned by reference
przy np. edytowaniu urządzenia sieciowego
