### PR TITLE
Fix 'Non-static method PEAR::isError() should not be called statically'

### DIFF
--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -3953,15 +3953,15 @@ class LMS {
 			$buf = $body;
 		}
 
-		$error = $mail_object = & Mail::factory('smtp', $params);
+		$error = $mail_object = @Mail::factory('smtp', $params);
 		//if (PEAR::isError($error))
-		if (is_a($error, 'PEAR_Error'))
-			return $error->getMessage();
+		if (is_a(@$error, 'PEAR_Error'))
+			return @$error->getMessage();
 
-		$error = $mail_object->send($recipients, $headers, $buf);
+		@$error = @$mail_object->send($recipients, $headers, $buf);
 		//if (PEAR::isError($error))
-		if (is_a($error, 'PEAR_Error'))
-			return $error->getMessage();
+		if (is_a(@$error, 'PEAR_Error'))
+			return @$error->getMessage();
 		else
 			return MSG_SENT;
 	}


### PR DESCRIPTION
for php5
