### PR TITLE
Nowe klasy CSS, uporządkowanie kilku tabel.

### DIFF
--- a/img/style.css
+++ b/img/style.css
@@ -237,3 +237,13 @@ table.lmsbox > tfoot > tr {
 .pagination {
     background-color: #CEBD9B;
 }
+
+table.lmsbox > thead { text-align: left; }
+
+td.empty-table { text-align: center; font-weight: bold; padding: 2em; }
+
+.nobr { white-space: nowrap; }
+.text-right { text-align: right; }
+.text-left { text-align: left; }
+.text-center { text-align: center; }
+.lighter { font-weight: lighter; }

--- a/templates/default/accountlist.html
+++ b/templates/default/accountlist.html
@@ -3,76 +3,82 @@
 {if $layout.module=="accountsearch"}{assign var=suffix value="&s=1"}{/if}
 <H1>{$layout.pagetitle}</H1>
 <P><TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 96%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
-	<TR">
-		<TD width="96%" NOWRAP>
+	<TR>
+		<TH scope="col">
+                        <SPAN class="nobr">
 			<IMG src="img/account.gif" alt=""> <A href="?m={$layout.module}{$suffix}&o=login{if $listdata.direction eq "asc" && $listdata.order eq "login"},desc{/if}"><B>{trans("Login<!account>")}</B></A> {if $listdata.order eq "login"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-			<B>@</B>
-			<A href="?m={$layout.module}{$suffix}&o=domain{if $listdata.direction eq "asc" && $listdata.order eq "domain"},desc{/if}">{trans("Domain:")}</A> {if $listdata.order eq "domain"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<IMG src="img/customer.gif" ALT=""> <A href="?m={$layout.module}{$suffix}&o=customername{if $listdata.direction eq "asc" && $listdata.order eq "customername"},desc{/if}">{trans("Owner:")}</A> {if $listdata.order eq "customername"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="1%" align="right" NOWRAP>
-			<A href="?m={$layout.module}{$suffix}&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("ID:")}</A> {if $listdata.order eq "id"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-		</TD>
-		<TD width="1%" align="right" NOWRAP>
-			{trans("Type (sh/mail/www/ftp/sql):")}<BR>
-			{trans("Quota (sh/mail/www/ftp/sql):")}
-		</TD>
-		<TD width="1%" NOWRAP align="right">
-			<A href="?m={$layout.module}{$suffix}&o=lastlogin{if $listdata.direction eq "asc" && $listdata.order eq "lastlogin"},desc{/if}">{trans("Last login:")}</A>{if $listdata.order eq "lastlogin"} <IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<A href="?m={$layout.module}{$suffix}&o=expdate{if $listdata.direction eq "asc" && $listdata.order eq "expdate"},desc{/if}">{trans("Expiration date:")}</A>{if $listdata.order eq "expdate"} <IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="1%" align="right" NOWRAP>
-			 <B>{t a=$listdata.total}Total: $a{/t}</B>&nbsp;
-		</TD>
+			@
+                        <A href="?m={$layout.module}{$suffix}&o=domain{if $listdata.direction eq "asc" && $listdata.order eq "domain"},desc{/if}">{trans("Domain:")}</A> {if $listdata.order eq "domain"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+                        <SPAN class="nobr lighter"><IMG src="img/customer.gif" ALT=""> <A href="?m={$layout.module}{$suffix}&o=customername{if $listdata.direction eq "asc" && $listdata.order eq "customername"},desc{/if}">{trans("Owner:")}</A> {if $listdata.order eq "customername"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr lighter"><A href="?m={$layout.module}{$suffix}&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("ID:")}</A> {if $listdata.order eq "id"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
+                        <SPAN class="nobr">{trans("Type (sh/mail/www/ftp/sql):")}</SPAN><BR>
+                        <SPAN class="nobr">{trans("Quota (sh/mail/www/ftp/sql):")}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
+                        <SPAN class="nobr"><A href="?m={$layout.module}{$suffix}&o=lastlogin{if $listdata.direction eq "asc" && $listdata.order eq "lastlogin"},desc{/if}">{trans("Last login:")}</A>{if $listdata.order eq "lastlogin"} <IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+                        <SPAN class="nobr"><A href="?m={$layout.module}{$suffix}&o=expdate{if $listdata.direction eq "asc" && $listdata.order eq "expdate"},desc{/if}">{trans("Expiration date:")}</A>{if $listdata.order eq "expdate"} <IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr">{t a=$listdata.total}Total: $a{/t}</SPAN>
+		</TH>
 	</TR>
 	<TR>
-	        <TD colspan="5">
-			<TABLE cellpadding="0" cellspacing="0">
-				<TR>
-					<TD width="1%" NOWRAP>
-						<FORM method="GET" action="?m={$layout.module}" name="filter">
-							<INPUT type="submit" class="hiddenbtn">
-							<INPUT type="HIDDEN" name="m" value="{$layout.module}">
-							{if $suffix}<INPUT type="HIDDEN" name="s" value="1">{/if}
-							<INPUT type="HIDDEN" name="page" value="1">
-							<B>{trans("Filter:")} </B> {trans("Owner:")}
-							<SELECT size="1" name="u" OnChange="document.filter.submit();">
-								<OPTION value=""{if $listdata.customer eq ""} SELECTED{/if}>{trans("- all owners -")}</OPTION>
-								<OPTION value="0"{if $listdata.customer eq "0"} SELECTED{/if}>{trans("SYSTEM ACCOUNT")}</OPTION>
-								{foreach from=$customerlist item=customer}
-					    				<OPTION value="{$customer.id}"{if $customer.id eq $listdata.customer} SELECTED{/if}>{$customer.customername|truncate:35:"...":true}</OPTION>
-								{/foreach}
-							</SELECT>&nbsp;
-							{trans("Type:")}
-							<SELECT size="1" name="t" ONCHANGE="document.filter.submit();">
-								<OPTION value="0"{if !$listdata.type} SELECTED {/if}>{trans("- all -")}</OPTION>
-								<OPTION value="1"{if $listdata.type eq 1} SELECTED {/if}>{trans("shell")}</OPTION>
-								<OPTION value="2"{if $listdata.type eq 2} SELECTED {/if}>{trans("mail")}</OPTION>
-								<OPTION value="4"{if $listdata.type eq 4} SELECTED {/if}>{trans("www")}</OPTION>
-								<OPTION value="8"{if $listdata.type eq 8} SELECTED {/if}>{trans("ftp")}</OPTION>
-								<OPTION value="16"{if $listdata.type eq 16} SELECTED {/if}>{trans("sql")}</OPTION>
-							</SELECT>&nbsp;
-							{trans("Status:")}
-							<SELECT size="1" name="k" OnChange="document.filter.submit();">
-								<OPTION value="0"{if !$listdata.kind} SELECTED {/if}>{trans("- all -")}</OPTION>
-								<OPTION value="1"{if $listdata.kind eq 1} SELECTED {/if}>{trans("expired")}</OPTION>
-								<OPTION value="2"{if $listdata.kind eq 2} SELECTED {/if}>{trans("active")}</OPTION>
-							</SELECT>&nbsp;
-							<NOBR>{trans("Domain:")}
-							<SELECT size="1" name="d" OnChange="document.filter.submit();">
-								<OPTION value=""{if $listdata.domain eq ""} SELECTED{/if}>{trans("- all -")}</OPTION>
-								{section name=domainlist loop=$domainlist}
-					    				<OPTION value="{$domainlist[domainlist].id}"{if $domainlist[domainlist].id eq $listdata.domain} SELECTED{/if}>{$domainlist[domainlist].name}</OPTION>
-								{/section}
-							</SELECT></NOBR>
-						</FORM>
-					</TD>
-					<TD width="99%" align="right" nowrap>
-						<A href="?m=accountadd{if $listdata.customer}&cid={$listdata.customer}{/if}{if $listdata.domain}&did={$listdata.domain}{/if}">{trans("New Account")} <IMG src="img/save.gif" alt=""></A>
-					</TD>
-				</TR>
-			</TABLE>
+	        <TD colspan="4">
+                        <SPAN class="nobr">
+                                <FORM method="GET" action="?m={$layout.module}" name="filter">
+                                        <INPUT type="submit" class="hiddenbtn">
+                                        <INPUT type="HIDDEN" name="m" value="{$layout.module}">
+                                        {if $suffix}<INPUT type="HIDDEN" name="s" value="1">{/if}
+                                        <INPUT type="HIDDEN" name="page" value="1">
+                                        <SPAN class="bold">{trans("Filter:")}</SPAN> {trans("Owner:")}
+                                        <SELECT size="1" name="u" OnChange="document.filter.submit();">
+                                                <OPTION value=""{if $listdata.customer eq ""} SELECTED{/if}>{trans("- all owners -")}</OPTION>
+                                                <OPTION value="0"{if $listdata.customer eq "0"} SELECTED{/if}>{trans("SYSTEM ACCOUNT")}</OPTION>
+                                                {foreach from=$customerlist item=customer}
+                                                <OPTION value="{$customer.id}"{if $customer.id eq $listdata.customer} SELECTED{/if}>{$customer.customername|truncate:35:"...":true}</OPTION>
+                                                {/foreach}
+                                        </SELECT>
+                                        {trans("Type:")}
+                                        <SELECT size="1" name="t" ONCHANGE="document.filter.submit();">
+                                                <OPTION value="0"{if !$listdata.type} SELECTED {/if}>{trans("- all -")}</OPTION>
+                                                <OPTION value="1"{if $listdata.type eq 1} SELECTED {/if}>{trans("shell")}</OPTION>
+                                                <OPTION value="2"{if $listdata.type eq 2} SELECTED {/if}>{trans("mail")}</OPTION>
+                                                <OPTION value="4"{if $listdata.type eq 4} SELECTED {/if}>{trans("www")}</OPTION>
+                                                <OPTION value="8"{if $listdata.type eq 8} SELECTED {/if}>{trans("ftp")}</OPTION>
+                                                <OPTION value="16"{if $listdata.type eq 16} SELECTED {/if}>{trans("sql")}</OPTION>
+                                        </SELECT>
+                                        {trans("Status:")}
+                                        <SELECT size="1" name="k" OnChange="document.filter.submit();">
+                                                <OPTION value="0"{if !$listdata.kind} SELECTED {/if}>{trans("- all -")}</OPTION>
+                                                <OPTION value="1"{if $listdata.kind eq 1} SELECTED {/if}>{trans("expired")}</OPTION>
+                                                <OPTION value="2"{if $listdata.kind eq 2} SELECTED {/if}>{trans("active")}</OPTION>
+                                        </SELECT>
+                                        {trans("Domain:")}
+                                        <SELECT size="1" name="d" OnChange="document.filter.submit();">
+                                                <OPTION value=""{if $listdata.domain eq ""} SELECTED{/if}>{trans("- all -")}</OPTION>
+                                                {section name=domainlist loop=$domainlist}
+                                                <OPTION value="{$domainlist[domainlist].id}"{if $domainlist[domainlist].id eq $listdata.domain} SELECTED{/if}>{$domainlist[domainlist].name}</OPTION>
+                                                {/section}
+                                        </SELECT>
+                                </FORM>
+                        </SPAN>
+                </TD>
+                <TD class="text-right">
+                        <SPAN class="nobr">
+                                <A href="?m=accountadd{if $listdata.customer}&cid={$listdata.customer}{/if}{if $listdata.domain}&did={$listdata.domain}{/if}">{trans("New Account")} <IMG src="img/save.gif" alt=""></A>
+                        </SPAN>
 		</TD>
 	</TR>
 	{if $listdata.total != 0}
@@ -88,7 +94,7 @@
 	{section name=accountlist loop=$accountlist start=$start max=$pagelimit}
 	<TR class="highlight {cycle}{if $accountlist[accountlist].expdate != 0 && $accountlist[accountlist].expdate < $smarty.now} blend{/if}"  >
 		<TD OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
-			<NOBR><IMG src="img/account.gif" alt=""> <B>{$accountlist[accountlist].login}@{$accountlist[accountlist].domain}</B></NOBR>
+                        <SPAN class="nobr bold"><IMG src="img/account.gif" alt=""> {$accountlist[accountlist].login}@{$accountlist[accountlist].domain}</SPAN>
 			{if $accountlist[accountlist].ownerid}
 			<BR><IMG src="img/customer.gif" alt="">
 			<A href="?m=customerinfo&id={$accountlist[accountlist].ownerid}">
@@ -96,34 +102,32 @@
 			</A>
 			{/if}
 		</TD>
-		<TD valign="top" NOWRAP OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
-			({$accountlist[accountlist].id|string_format:"%04d"})<BR>
+		<TD OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
+			({$accountlist[accountlist].id|string_format:"%04d"})
 		</TD>
-		<TD align="right" NOWRAP valign="top" OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
+		<TD class="text-right" OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
 			{if ($accountlist[accountlist].type & 1) == 1}*{else}-{/if}/{if ($accountlist[accountlist].type & 2) == 2}*{else}-{/if}/{if ($accountlist[accountlist].type & 4) == 4}*{else}-{/if}/{if ($accountlist[accountlist].type & 8) == 8}*{else}-{/if}/{if ($accountlist[accountlist].type & 16) == 16}*{else}-{/if}<BR>
 			{$accountlist[accountlist].quota_sh}/{$accountlist[accountlist].quota_mail}/{$accountlist[accountlist].quota_www}/{$accountlist[accountlist].quota_ftp}/{$accountlist[accountlist].quota_sql}
 		</TD>
-		<TD align="right" valign="top" OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
-			<nobr>{if $accountlist[accountlist].lastlogin}{$accountlist[accountlist].lastlogin|date_format:"%Y/%m/%d %H:%M"}{/if}</nobr><BR>
-			<nobr>{if $accountlist[accountlist].expdate}{$accountlist[accountlist].expdate|date_format:"%Y/%m/%d"}{/if}</nobr>
+		<TD class="text-right" OnClick="return self.location.href='?m=accountinfo&id={$accountlist[accountlist].id}';">
+			<SPAN class="nobr">{if $accountlist[accountlist].lastlogin}{$accountlist[accountlist].lastlogin|date_format:"%Y/%m/%d %H:%M"}{/if}</SPAN><BR>
+			<SPAN class="nobr">{if $accountlist[accountlist].expdate}{$accountlist[accountlist].expdate|date_format:"%Y/%m/%d"}{/if}</SPAN>
 		</TD>
-		<TD align="right">
+		<TD class="text-right">
 			{assign var=account value="`$accountlist[accountlist].login`@`$accountlist[accountlist].domain`"}
-			<NOBR>
+			<SPAN class="nobr">
 			<A href="?m=accountpasswd&id={$accountlist[accountlist].id}"><IMG src="img/pass.gif" alt="[ {trans("Change password")} ]" title="[ {trans("Change password")} ]"></A> 
 			<A href="?m=aliasadd&accountid={$accountlist[accountlist].id}"><IMG src="img/alias.gif" alt="[ {trans("Create alias")} ]" title="[ {trans("Create alias")} ]"></A> 
 			<A href="?m=accountdel&id={$accountlist[accountlist].id}" OnClick="return confirmLink(this, '{t a=$account}Are you sure, you want to delete account \'$a\' and all assigned to them aliases?{/t}')"><IMG src="img/delete.gif" title="[ {trans("Delete")} ]" alt="[ {trans("Delete")} ]"></A> 
 			<A href="?m=accountedit&id={$accountlist[accountlist].id}"><IMG src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A> 
 			<A href="?m=accountinfo&id={$accountlist[accountlist].id}"><IMG src="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A> 
-			</NOBR>
+                        </SPAN>
 		</TD>
 	</TR>
 	{sectionelse}
 	<TR>
-		<TD colspan="5" align="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("No such accounts in database.")}</B></p>
-			<p>&nbsp;</p>
+		<TD colspan="5" class="empty-table">
+			{trans("No such accounts in database.")}
 		</TD>
 	</TR>
 	{/section}
@@ -137,11 +141,11 @@
 	</TR>
 	{/if}
 	<TR>
-		<TD colspan="3" align="right" valign="top">
-			<B>{trans("Total:")} {sum array=$accountlist column=quota_sh}/{sum array=$accountlist column=quota_mail}/{sum array=$accountlist column=quota_www}/{sum array=$accountlist column=quota_ftp}/{sum array=$accountlist column=quota_sql}</B>	
+		<TD colspan="3" class="text-right bold">
+                        <SPAN class="nobr">{trans("Total:")} {sum array=$accountlist column=quota_sh}/{sum array=$accountlist column=quota_mail}/{sum array=$accountlist column=quota_www}/{sum array=$accountlist column=quota_ftp}/{sum array=$accountlist column=quota_sql}</SPAN>
 		</TD>
-		<TD colspan="2" align="right">
-			<A href="?m=accountadd{if $listdata.customer}&cid={$listdata.customer}{/if}{if $listdata.domain}&did={$listdata.domain}{/if}">{trans("New Account")} <IMG src="img/save.gif" alt=""></A>
+		<TD colspan="2" class="text-right">
+                        <SPAN class="nobr"><A href="?m=accountadd{if $listdata.customer}&cid={$listdata.customer}{/if}{if $listdata.domain}&did={$listdata.domain}{/if}">{trans("New Account")} <IMG src="img/save.gif" alt=""></A></SPAN>
 		</TD>
 	</TR>
     </TFOOT>

--- a/templates/default/aliaslist.html
+++ b/templates/default/aliaslist.html
@@ -3,56 +3,60 @@
  {if $layout.module=="aliassearch"}{assign var=suffix value="&s=1"}{/if}
 <H1>{$layout.pagetitle}</H1>
 <P><TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 41%;">
+        <COL style="width: 1%;">
+        <COL style="width: 57%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR>
-		<TD width="41%" nowrap>
-			<IMG src="img/alias.gif" alt=""> <A href="?m={$layout.module}{$suffix}&o=login{if $listdata.direction eq "asc" && $listdata.order eq "login"},desc{/if}"><B>{trans("Login<!account>")}</B></A> {if $listdata.order eq "login"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-			<B>@</B>
-			<A href="?m={$layout.module}{$suffix}&o=domain{if $listdata.direction eq "asc" && $listdata.order eq "domain"},desc{/if}"><B>{trans("Domain:")}</B></A> {if $listdata.order eq "domain"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="1%" align="right">
-			<A href="?m={$layout.module}{$suffix}&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("ID:")}</A> {if $listdata.order eq "id"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="57%" NOWRAP>
-			<IMG src="img/account.gif" alt=""> <A href="?m={$layout.module}{$suffix}&o=dest{if $listdata.direction eq "asc" && $listdata.order eq "dest"},desc{/if}">{trans("Destination:")}</A> {if $listdata.order eq "dest"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="1%" NOWRAP>
-			 <B>{t a=$listdata.total}Total: $a{/t}</B>
-		</TD>
+		<TH scope="col">
+                        <SPAN class="nobr">
+			<IMG src="img/alias.gif" alt=""> <A href="?m={$layout.module}{$suffix}&o=login{if $listdata.direction eq "asc" && $listdata.order eq "login"},desc{/if}">{trans("Login<!account>")}</A> {if $listdata.order eq "login"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
+			@
+			<A href="?m={$layout.module}{$suffix}&o=domain{if $listdata.direction eq "asc" && $listdata.order eq "domain"},desc{/if}">{trans("Domain:")}</A> {if $listdata.order eq "domain"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
+                        </SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
+                        <SPAN class="nobr"><A href="?m={$layout.module}{$suffix}&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("ID:")}</A> {if $listdata.order eq "id"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
+                        <SPAN class="nobr"><IMG src="img/account.gif" alt=""> <A href="?m={$layout.module}{$suffix}&o=dest{if $listdata.direction eq "asc" && $listdata.order eq "dest"},desc{/if}">{trans("Destination:")}</A> {if $listdata.order eq "dest"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr">{t a=$listdata.total}Total: $a{/t}</SPAN>
+		</TH>
 	</TR>
 	<TR>
-		<TD colspan="4">
-			<TABLE cellpadding="0" cellspacing="0">
-		    		<TR>
-					<TD width="1%" NOWRAP>
-		        			<FORM method="GET" action="?m={$layout.module}" name="filter">
-							<INPUT type="submit" class="hiddenbtn">
-							<INPUT type="HIDDEN" name="m" value="{$layout.module}">
-							{if $suffix}<INPUT type="HIDDEN" name="s" value="1">{/if}
-							<INPUT type="HIDDEN" name="page" value="1">
-							<B>{trans("Filter:")} </B> {trans("Domain's owner:")}
-							<SELECT size="1" name="u" OnChange="document.filter.submit();">
-								<OPTION value=""{if $listdata.customer eq ""} SELECTED{/if}>{trans("- all owners -")}</OPTION>
-								<OPTION value="0"{if $listdata.customer eq "0"} SELECTED{/if}>{trans("SYSTEM DOMAIN")}</OPTION>
-								{foreach from=$customerlist item=customer}
-					    				<OPTION value="{$customer.id}"{if $customer.id eq $listdata.customer} SELECTED{/if}>{$customer.customername|truncate:40:"..."}</OPTION>
-								{/foreach}
-							</SELECT>&nbsp;
-							{trans("Domain:")}
-							<SELECT size="1" name="d" OnChange="document.filter.submit();">
-								<OPTION value=""{if $listdata.domainid eq ""} SELECTED{/if}>{trans("- all -")}</OPTION>
-							{foreach from=$domainlist item=item}
-					    			<OPTION value="{$item.id}"{if $item.id eq $listdata.domain} SELECTED{/if}>{$item.name}</OPTION>
-							{/foreach}
-							</SELECT>
-						</FORM>
-					</TD>
-					<TD width="99%" align="right" nowrap>
-						<A href="?m=aliasadd{if $listdata.domain}&domainid={$listdata.domain}{/if}">{trans("New Alias")} <IMG src="img/save.gif" alt=""></A>
-					</TD>
-		    		</TR>
-			</TABLE>
-		</TD>
+		<TD colspan="3">
+                        <SPAN class="nobr">
+                                <FORM method="GET" action="?m={$layout.module}" name="filter">
+                                        <INPUT type="submit" class="hiddenbtn">
+                                        <INPUT type="HIDDEN" name="m" value="{$layout.module}">
+                                        {if $suffix}<INPUT type="HIDDEN" name="s" value="1">{/if}
+                                        <INPUT type="HIDDEN" name="page" value="1">
+                                        <B>{trans("Filter:")} </B> {trans("Domain's owner:")}
+                                        <SELECT size="1" name="u" OnChange="document.filter.submit();">
+                                                <OPTION value=""{if $listdata.customer eq ""} SELECTED{/if}>{trans("- all owners -")}</OPTION>
+                                                <OPTION value="0"{if $listdata.customer eq "0"} SELECTED{/if}>{trans("SYSTEM DOMAIN")}</OPTION>
+                                                {foreach from=$customerlist item=customer}
+                                                <OPTION value="{$customer.id}"{if $customer.id eq $listdata.customer} SELECTED{/if}>{$customer.customername|truncate:40:"..."}</OPTION>
+                                                {/foreach}
+                                        </SELECT>&nbsp;
+                                        {trans("Domain:")}
+                                        <SELECT size="1" name="d" OnChange="document.filter.submit();">
+                                                <OPTION value=""{if $listdata.domainid eq ""} SELECTED{/if}>{trans("- all -")}</OPTION>
+                                        {foreach from=$domainlist item=item}
+                                                <OPTION value="{$item.id}"{if $item.id eq $listdata.domain} SELECTED{/if}>{$item.name}</OPTION>
+                                        {/foreach}
+                                        </SELECT>
+                                </FORM>
+                        </SPAN>
+                </TD>
+                <TD class="text-right">
+                        <SPAN class="nobr"><A href="?m=aliasadd{if $listdata.domain}&domainid={$listdata.domain}{/if}">{trans("New Alias")} <IMG src="img/save.gif" alt=""></A></SPAN>
+                </TD>
 	</TR>		
 	{if $listdata.total != 0}
 	<TR>
@@ -66,29 +70,29 @@
 	{cycle values="light,lucid" print=false}
 	{section name=aliaslist loop=$aliaslist start=$start max=$pagelimit}
 	<TR class="highlight {cycle}{if $aliaslist[aliaslist].expdate != 0 && $aliaslist[aliaslist].expdate < $smarty.now} blend{/if}"  >
-		<TD nowrap onclick="return self.location.href='?m=aliasinfo&id={$aliaslist[aliaslist].id}';">
-			<IMG src="img/alias.gif" ALT="" > <B>{$aliaslist[aliaslist].login}@{$aliaslist[aliaslist].domain}</B>
+		<TD onclick="return self.location.href='?m=aliasinfo&id={$aliaslist[aliaslist].id}';">
+                        <SPAN class="nobr bold"><IMG src="img/alias.gif" ALT="" > {$aliaslist[aliaslist].login}@{$aliaslist[aliaslist].domain}</SPAN>
 		</TD>
-		<TD align="right" onclick="return self.location.href='?m=aliasinfo&id={$aliaslist[aliaslist].id}';">
+		<TD class="text-right" onclick="return self.location.href='?m=aliasinfo&id={$aliaslist[aliaslist].id}';">
 			({$aliaslist[aliaslist].id|string_format:"%04d"})
 		</TD>
 		<TD onclick="return self.location.href='?m=aliasinfo&id={$aliaslist[aliaslist].id}';">
 			{if $aliaslist[aliaslist].accounts}<IMG src="img/account.gif" alt="">{$aliaslist[aliaslist].accounts|replace:",":"<BR><IMG src=\"img/account.gif\" alt=\"\">"}{/if}<BR>
 			{if $aliaslist[aliaslist].forwards}<IMG src="img/forward.gif" alt="">{$aliaslist[aliaslist].forwards|replace:",":"<BR><IMG src=\"img/forward.gif\" alt=\"\">"}{/if}
 		</TD>
-		<TD align="right" NOWRAP>
+		<TD class="text-right">
 			{assign var=alias value="`$aliaslist[aliaslist].login`@`$aliaslist[aliaslist].domain`"}
+                        <SPAN class="nobr">
 			<A href="?m=aliasdel&id={$aliaslist[aliaslist].id}" OnClick="return confirmLink(this, '{t a=$alias}Are you sure, you want to delete alias: \'$a\'?{/t}')"><IMG src="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 			<A href="?m=aliasedit&id={$aliaslist[aliaslist].id}"><IMG src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A> 
 			<A href="?m=aliasinfo&id={$aliaslist[aliaslist].id}"><IMG src="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A> 
+                        </SPAN>
 		</TD>
 	</TR>
 	{sectionelse}
 	<TR>
-		<TD colspan="4" align="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("No such aliases in database.")}</B></p>
-			<p>&nbsp;</p>
+		<TD colspan="4" class="empty-table">
+			{trans("No such aliases in database.")}
 		</TD>
 	</TR>
 	{/section}
@@ -102,11 +106,11 @@
     </TBODY>
     <TFOOT>
 	<TR>
-		<TD colspan="2" align="right" valign="top">
-			<IMG SRC="img/info2.gif" alt=""> <B>{t a=$listdata.total}Total: $a{/t}</B>
+		<TD colspan="2" class="text-right">
+                        <SPAN class="nobr bold"><IMG SRC="img/info2.gif" alt=""> {t a=$listdata.total}Total: $a{/t}</SPAN>
 		</TD>
-		<TD colspan="2" align="right">
-			<A href="?m=aliasadd{if $listdata.domain}&domainid={$listdata.domain}{/if}">{trans("New Alias")} <IMG src="img/save.gif" alt=""></A>
+		<TD colspan="2" class="text-right">
+                        <SPAN class="nobr"><A href="?m=aliasadd{if $listdata.domain}&domainid={$listdata.domain}{/if}">{trans("New Alias")} <IMG src="img/save.gif" alt=""></A></SPAN>
 		</TD>
 	</TR>
     </TFOOT>

--- a/templates/default/balancelist.html
+++ b/templates/default/balancelist.html
@@ -70,72 +70,84 @@
 <FORM METHOD="POST" NAME="page">
 <INPUT type="submit" class="hiddenbtn">
 <TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 91%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR>
-		<TD width="1%">
+		<TH scope="col">
 			{trans("Date:")}
-		</TD>
-		<TD width="1%">
+		</TH>
+		<TH scope="col">
 			{trans("User:")}
-		</TD>
-		<TD width="1%" align="right">
+		</TH>
+		<TH scope="col" class="text-right">
 			{trans("Liability:")}
-		</TD>
-		<TD width="1%" align="right">
+		</TH>
+		<TH scope="col" class="text-right">
 			{trans("Income:")}
-		</TD>
-		<TD width="1%" align="right">
+		</TH>
+		<TH scope="col" class="text-right">
 			{trans("Expense:")}
-		</TD>
-		<TD width="1%" align="center">&raquo;</TD>
-		<TD width="1%" align="right">
+		</TH>
+		<TH scope="col" class="text-center">&raquo;</TH>
+		<TH scope="col" class="text-right">
 			{trans("After:")}
-		</TD>
-		<TD width="1%">
+		</TH>
+                <TH scope="col">
 			{trans("Customer:")}
-		</TD>
-		<TD width="91%">
+		</TH>
+		<TH scope="col">
 			{trans("Description:")}
-		</TD>
-		<TD width="1%">&nbsp;</TD>
+		</TH>
+		<TH scope="col">&nbsp;</TH>
 	</TR>
 	<TR>
 		<TD colspan="10">
-			<B>{trans("Filter:")} </B>
-				<INPUT type="text" name="search" value="{$listdata.search}" size="15" {tip text="Enter value of searching data and select category"}>
-				<SELECT size="1" name="cat" style="width: 150px">
-					<OPTION value=""{if $listdata.cat eq ""} SELECTED{/if}>{trans("- select category -")}</OPTION>
-					<OPTION value="comment"{if $listdata.cat eq "comment"} SELECTED{/if}>{trans("comment")}</OPTION>
-					<OPTION value="cdate"{if $listdata.cat eq "cdate"} SELECTED{/if}>{trans("date (YYYY/MM/DD)")}</OPTION>
-					<OPTION value="number"{if $listdata.cat eq "number"} SELECTED{/if}>{trans("document number")}</OPTION>
-					<OPTION value="value"{if $listdata.cat eq "value"} SELECTED{/if}>{trans("value")}</OPTION>
-					<OPTION value="name"{if $listdata.cat eq "name"} SELECTED{/if}>{trans("customer name")}</OPTION>
-					<OPTION value="customerid"{if $listdata.cat eq "customerid"} SELECTED{/if}>{trans("customer ID")}</OPTION>
-					<OPTION value="ten"{if $listdata.cat eq "ten"} SELECTED{/if}>{trans("TEN")}</OPTION>
-					<OPTION value="address"{if $listdata.cat eq "address"} SELECTED{/if}>{trans("address")}</OPTION>
-					<OPTION value="documented"{if $listdata.cat eq "documented"} SELECTED{/if}>{trans("with document")}</OPTION>
-					<OPTION value="notdocumented"{if $listdata.cat eq "notdocumented"} SELECTED{/if}>{trans("without document")}</OPTION>
-				</SELECT>&nbsp;
-				{trans("Group:")}
-				<SELECT size="1" name="group">
-					<OPTION value="0"{if !$listdata.group} SELECTED{/if}>{trans("- all groups -")}</OPTION>
-					{section name="grouplist" loop=$grouplist}
-					<OPTION value="{$grouplist[grouplist].id}"{if $listdata.group eq $grouplist[grouplist].id} SELECTED{/if}>{$grouplist[grouplist].name|truncate:40:"...":true}</OPTION>
-					{/section}
-				</SELECT>
-				<NOBR>
-				<INPUT type="checkbox" name="groupexclude" id="groupexclude"{if $listdata.groupexclude} CHECKED{/if}><label for="groupexclude">{trans("exclude group")}</label>
-				</NOBR>
-				<NOBR>
-				{trans("From:")}&nbsp;<INPUT TYPE="text" NAME="from" SIZE="10" MAXSIZE="10" value="{if $listdata.from > 0}{$listdata.from|date_format:"%Y/%m/%d"}{/if}" OnClick="javascript:cal1.popup();" {tip text="Enter date in YYYY/MM/DD format (empty field means no limit) or click to choose it from calendar"}>
-				{trans("To:")}&nbsp;<INPUT TYPE="text" NAME="to" SIZE="10" MAXSIZE="10" value="{if $listdata.to > 0}{$listdata.to|date_format:"%Y/%m/%d"}{/if}" OnClick="javascript:cal2.popup();"  {tip text="Enter date in YYYY/MM/DD format (empty field means no limit) or click to choose it from calendar"}>&nbsp;
-				<A href="javascript: filter();">&raquo;&raquo;&raquo;</A><BR>
-				</NOBR>
+                        <SPAN class="nobr bold">{trans("Filter:")} </SPAN>
+                        <INPUT type="text" name="search" value="{$listdata.search}" size="15" {tip text="Enter value of searching data and select category"}>
+                        <SELECT size="1" name="cat" style="width: 150px">
+                                <OPTION value=""{if $listdata.cat eq ""} SELECTED{/if}>{trans("- select category -")}</OPTION>
+                                <OPTION value="comment"{if $listdata.cat eq "comment"} SELECTED{/if}>{trans("comment")}</OPTION>
+                                <OPTION value="cdate"{if $listdata.cat eq "cdate"} SELECTED{/if}>{trans("date (YYYY/MM/DD)")}</OPTION>
+                                <OPTION value="number"{if $listdata.cat eq "number"} SELECTED{/if}>{trans("document number")}</OPTION>
+                                <OPTION value="value"{if $listdata.cat eq "value"} SELECTED{/if}>{trans("value")}</OPTION>
+                                <OPTION value="name"{if $listdata.cat eq "name"} SELECTED{/if}>{trans("customer name")}</OPTION>
+                                <OPTION value="customerid"{if $listdata.cat eq "customerid"} SELECTED{/if}>{trans("customer ID")}</OPTION>
+                                <OPTION value="ten"{if $listdata.cat eq "ten"} SELECTED{/if}>{trans("TEN")}</OPTION>
+                                <OPTION value="address"{if $listdata.cat eq "address"} SELECTED{/if}>{trans("address")}</OPTION>
+                                <OPTION value="documented"{if $listdata.cat eq "documented"} SELECTED{/if}>{trans("with document")}</OPTION>
+                                <OPTION value="notdocumented"{if $listdata.cat eq "notdocumented"} SELECTED{/if}>{trans("without document")}</OPTION>
+                        </SELECT>
+                        {trans("Group:")}
+                        <SELECT size="1" name="group">
+                                <OPTION value="0"{if !$listdata.group} SELECTED{/if}>{trans("- all groups -")}</OPTION>
+                                {section name="grouplist" loop=$grouplist}
+                                <OPTION value="{$grouplist[grouplist].id}"{if $listdata.group eq $grouplist[grouplist].id} SELECTED{/if}>{$grouplist[grouplist].name|truncate:40:"...":true}</OPTION>
+                                {/section}
+                        </SELECT>
+                        <SPAN class="nobr">
+                        <INPUT type="checkbox" name="groupexclude" id="groupexclude"{if $listdata.groupexclude} CHECKED{/if}><label for="groupexclude">{trans("exclude group")}</label>
+                        </SPAN>
+                        <SPAN class="nobr">
+                        {trans("From:")} <INPUT TYPE="text" NAME="from" SIZE="10" MAXSIZE="10" value="{if $listdata.from > 0}{$listdata.from|date_format:"%Y/%m/%d"}{/if}" OnClick="javascript:cal1.popup();" {tip text="Enter date in YYYY/MM/DD format (empty field means no limit) or click to choose it from calendar"}>
+                        {trans("To:")} <INPUT TYPE="text" NAME="to" SIZE="10" MAXSIZE="10" value="{if $listdata.to > 0}{$listdata.to|date_format:"%Y/%m/%d"}{/if}" OnClick="javascript:cal2.popup();"  {tip text="Enter date in YYYY/MM/DD format (empty field means no limit) or click to choose it from calendar"}>
+                        <A href="javascript: filter();">&raquo;&raquo;&raquo;</A><BR>
+                        </SPAN>
 		</TD>
 	</TR>
 	{if $listdata.total != 0}
 	<TR>
-		<TD class="pagination" WIDTH="100%" COLSPAN="10">
+		<TD class="pagination" COLSPAN="10">
 			{include file="scroller.html" loop=$balancelist scrollerno=1}
 		</TD>
 	</TR>
@@ -145,38 +157,35 @@
 	{cycle values="light,lucid" print=false}
 	{section name=balancelist loop=$balancelist start=$start max=$pagelimit}
 	<TR class="highlight {cycle}"  >
-		<TD width="1%" nowrap>
-			{$balancelist[balancelist].time|date_format:"%Y/%m/%d %H:%M"}
+		<TD>
+                        <SPAN class="nobr">{$balancelist[balancelist].time|date_format:"%Y/%m/%d %H:%M"}</SPAN>
 		</TD>
-		<TD width="1%" nowrap>
-			{if $balancelist[balancelist].userid}<NOBR>{$balancelist[balancelist].user|truncate:16:"...":true}</NOBR>{else}-{/if}
+		<TD>
+			{if $balancelist[balancelist].userid}<SPAN class="nobr">{$balancelist[balancelist].user|truncate:16:"...":true}</SPAN>{else}-{/if}
 		</TD>
-		<TD width="1%" align="right" nowrap>
-			{if $balancelist[balancelist].covenant}{($balancelist[balancelist].value*-1)|money_format}{else}-{/if}
+		<TD class="text-right">
+			{if $balancelist[balancelist].covenant}<SPAN class="nobr">{($balancelist[balancelist].value*-1)|money_format}</SPAN>{else}-{/if}
 		</TD>
-		<TD width="1%" align="right" nowrap>
-			{if !$balancelist[balancelist].covenant && $balancelist[balancelist].value > 0}{$balancelist[balancelist].value|money_format}{else}-{/if}
+		<TD class="text-right">
+                        {if !$balancelist[balancelist].covenant && $balancelist[balancelist].value > 0}<SPAN class="nobr">{$balancelist[balancelist].value|money_format}</SPAN>{else}-{/if}
 		</TD>
-		<TD width="1%" align="right" nowrap>
-			{if !$balancelist[balancelist].covenant && $balancelist[balancelist].value < 0}{($balancelist[balancelist].value*-1)|money_format}{else}-{/if}
+		<TD class="text-right">
+			{if !$balancelist[balancelist].covenant && $balancelist[balancelist].value < 0}<SPAN class="nobr">{($balancelist[balancelist].value*-1)|money_format}</SPAN>{else}-{/if}
 		</TD>
-		<TD width="1%" align="center">
+		<TD class="text-center">
 			&raquo;
 		</TD>
-		<TD width="1%" align="right" nowrap>
-			{if $balancelist[balancelist].covenant}
-			-
-			{else}
-			{$balancelist[balancelist].after|money_format}
-			{/if}
+		<TD class="text-right">
+                        {if $balancelist[balancelist].covenant}-{else}<SPAN class="nobr">{$balancelist[balancelist].after|money_format}</SPAN>{/if}
 		</TD>
-		<TD width="1%" nowrap>
-			{if $balancelist[balancelist].customerid}<NOBR><A HREF="?m=customerinfo&id={$balancelist[balancelist].customerid}">{$balancelist[balancelist].customername|truncate:20:"...":true}</A></NOBR>{else} - {/if}
+		<TD class="text-right">
+			{if $balancelist[balancelist].customerid}<SPAN class="nobr"><A HREF="?m=customerinfo&id={$balancelist[balancelist].customerid}">{$balancelist[balancelist].customername|truncate:20:"...":true}</A></SPAN>{else} - {/if}
 		</TD>
-		<TD width="91%">
+		<TD>
 			{$balancelist[balancelist].comment}
 		</TD>
-		<TD width="1%" align="right" nowrap>
+		<TD class="text-right">
+                        <SPAN class="nobr">
 			{if $balancelist[balancelist].docid}
 				{if $balancelist[balancelist].doctype==$smarty.const.DOC_INVOICE}
 				<A HREF="?m=invoice&id={$balancelist[balancelist].docid}" target="_BLANK"><IMG SRC="img/print.gif" ALT="[ {trans("Invoice")} ]" {tip a=$balancelist[balancelist].docid dynpopup='?m=number&id=$a'}></A>
@@ -189,62 +198,61 @@
 				{/if}
 			{/if}
 			<INPUT TYPE="checkbox" NAME="marks[{$balancelist[balancelist].id}]" VALUE="{$balancelist[balancelist].id}">
+                        </SPAN>
 		</TD>
 	</TR>
 	{sectionelse}
 	<TR>
-		<TD WIDTH="100%" ALIGN="center" COLSPAN="10">
-			<P>&nbsp;</P>
-			<P><B>{trans("No such transactions found in database.")}</B></P>
-			<P>&nbsp;</P>
+		<TD COLSPAN="10" class="empty-table">
+			{trans("No such transactions found in database.")}
 		</TD>
 	</TR>
 	{/section}
     </TBODY>
     <TFOOT>
 	<TR>
-		<TD COLSPAN="8" nowrap>
+		<TD COLSPAN="8">
+                        <SPAN class="nobr">
 			<A HREF="javascript:DeleteMarked();">{trans("Delete")} <IMG SRC="img/delete.gif" ALT="{trans("Delete")}" HSPACE="2"></A>&nbsp;
 			<A HREF="javascript:printi();">{trans("Print invoices")} <IMG SRC="img/print.gif" ALT="" HSPACE="2"></A>&nbsp;
 			<A HREF="javascript:printr();">{trans("Print cash receipts")} <IMG SRC="img/printr.gif" ALT="" HSPACE="2"></A>&nbsp;
 			<INPUT type="checkbox" name="original" id="original"{if preg_match('/original/i', get_conf('invoices.default_printpage'))} checked{/if}><label for="original">{trans("original")}</label>
 			<INPUT type="checkbox" name="copy" id="copy"{if preg_match('/copy/i', get_conf('invoices.default_printpage'))} checked{/if}><label for="copy">{trans("copy")}</label>
 			<INPUT type="checkbox" name="duplicate" id="duplicate"{if preg_match('/duplicate/i', get_conf('invoices.default_printpage'))} checked{/if}><label for="duplicate">{trans("duplicate")}</label>
+                        </SPAN>
 		</TD>
-		<TD ALIGN="right" colspan="2">
-			<label for="allbox">{trans("Check All")}</label><INPUT TYPE="checkbox" NAME="allbox" id="allbox" onchange="CheckAll('page', this, ['original', 'duplicate', 'copy'])" VALUE="1">
+		<TD colspan="2" class="text-right">
+                        <SPAN class="nobr"><label for="allbox">{trans("Check All")}</label><INPUT TYPE="checkbox" NAME="allbox" id="allbox" onchange="CheckAll('page', this, ['original', 'duplicate', 'copy'])" VALUE="1"></SPAN>
 		</TD>
 	</TR>
 	{if $listdata.total != 0}
 	<TR>
-		<TD class="pagination" WIDTH="100%" COLSPAN="10">
+		<TD class="pagination" COLSPAN="10">
 			{include file="scroller.html" loop=$balancelist scrollerno=2}
 		</TD>
 	</TR>
 	{/if}
 	<TR>
-		<TD colspan="2" align="right" NOWRAP>
-			<B>{trans("Total:")}</B><BR>
+		<TD colspan="2" class="text-right bold">
+			{trans("Total:")}
 		</TD>
-		<TD nowrap align="right">
-			<B>{$listdata.liability|money_format}</B>
+		<TD class="text-right bold nobr">
+			{$listdata.liability|money_format}
 		</TD>
-		<TD nowrap align="right">
-			<B>{$listdata.income|money_format}</B>
+		<TD class="text-right bold nobr">
+			{$listdata.income|money_format}
 		</TD>
-		<TD nowrap align="right">
-			<B>{$listdata.expense|money_format}</B>
+		<TD class="text-right bold nobr">
+			{$listdata.expense|money_format}
 		</TD>
-		<TD nowrap align="right" colspan="2">
+                <TD colspan="2">&nbsp;</TD>
+		<TD class="text-right bold nobr">
+			{trans("Balance:")}
 		</TD>
-		<TD nowrap align="right">
-			<B>{trans("Balance:")}</B>
+		<TD class="bold nobr">
+			{$listdata.totalval|money_format}
 		</TD>
-		<TD nowrap align="left">
-			<B>{$listdata.totalval|money_format}</B>
-		</TD>
-		<TD>&nbsp;
-		</TD>
+		<TD>&nbsp;</TD>
 	</TR>
     </TFOOT>
 </TABLE>

--- a/templates/default/cashreglist.html
+++ b/templates/default/cashreglist.html
@@ -2,80 +2,85 @@
 <!-- $Id$ -->
 <H1>{$layout.pagetitle}</H1>
 <TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 95%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR>
-		<TD WIDTH="1%" NOWRAP>
-			<IMG src="img/queue.gif" ALT=""> <B>{trans("Name:")}</B>
-		</TD>
-		<TD WIDTH="1%" NOWRAP>
-			{trans("ID:")}
-		</TD>
-		<TD align="right" WIDTH="1%" NOWRAP>
-			{trans("Cash state:")}
-		</TD>
-		<TD WIDTH="1%" ALIGN="right" NOWRAP>
-			{trans("Cash-in receipt numbering plan:")}<BR>
-			{trans("Cash-out receipt numbering plan:")}
-		</TD>
-		<TD WIDTH="95%">
-			{trans("Description:")}
-		</TD>
-		<TD WIDTH="1%" align="right" nowrap>
-			<A href="?m=cashregadd">{trans("Add registry")} <IMG src="img/save.gif" alt=""> </A>
-		</TD>
+		<TH scope="col">
+                        <SPAN class="nobr"><IMG src="img/queue.gif" ALT=""> {trans("Name:")}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr lighter">{trans("ID:")}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr lighter">{trans("Cash state:")}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
+                        <SPAN class="nobr">{trans("Cash-in receipt numbering plan:")}</SPAN><BR>
+                        <SPAN class="nobr">{trans("Cash-out receipt numbering plan:")}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr lighter">{trans("Description:")}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
+                        <SPAN class="nobr"><A href="?m=cashregadd">{trans("Add registry")} <IMG src="img/save.gif" alt=""> </A></SPAN>
+		</TH>
 	</TR>
     </THEAD>
     <TBODY>
 	{cycle values="light,lucid" print=false}
 	{foreach from=$reglist item=reg}
-	<TR class="highlight {cycle}{if $reg.disabled} blend{/if}"  >
-		<TD nowrap onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';">
-			<IMG src="img/queue.gif" ALT=""> <B>{$reg.name}</B>
+	<TR class="highlight {cycle}{if $reg.disabled} blend{/if}">
+		<TD onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';">
+                        <SPAN class="nobr bold"><IMG src="img/queue.gif" ALT=""> {$reg.name}</SPAN>
 		</TD>
-		<TD ALIGN="right">
+		<TD class="text-right">
 			({$reg.id|string_format:"%04d"})
 		</TD>
-		<TD ALIGN="right" onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';" NOWRAP>
-			{if $reg.balance < 0}<font class="alert">{/if}
-			{$reg.balance|money_format}
-			{if $reg.balance < 0}</font>{/if}
+		<TD  class="text-right{if $reg.balance < 0} alert{/if}" onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';">
+                        <SPAN class="nobr">{$reg.balance|money_format}</SPAN>
 		</TD>
-		<TD ALIGN="right" onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';">
+		<TD class="text-right" onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';">
 			{$reg.in_template|default:"%N/LMS/%Y"}<BR>
 			{$reg.out_template|default:"%N/LMS/%Y"}
 		</TD>
 		<TD onClick="return self.location.href='?m=receiptlist&regid={$reg.id}';">
 			{$reg.description}
 		</TD>
-		<TD align="right" NOWRAP>
+		<TD class="text-right">
+                        <SPAN class="nobr">
 			<A HREF="?m=receiptlist&regid={$reg.id}"><IMG SRC="img/view.gif" alt="[ {trans("Browse")} ]" title="[ {trans("Browse")} ]"></A>
 			<A HREF="?m=cashregdel&id={$reg.id}" OnClick="return confirmLink(this, '{t a=$reg.name}Are you sure, you want to remove registry \'$a\' and all assigned receipts?{/t}');"><IMG SRC="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 			<A HREF="?m=cashregedit&id={$reg.id}"><IMG SRC="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A>
 			<A HREF="?m=cashreginfo&id={$reg.id}"><IMG SRC="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A>
+                        </SPAN>
 		</TD>
 	</TR>
 	{foreachelse}
 	<TR>
-		<TD colspan="6" align="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("There are no cash registries.")}<B></p>
-			<p>&nbsp;</p>
+		<TD colspan="6" class="empty-table">
+			{trans("There are no cash registries.")}
 		</TD>
 	</TR>
 	{/foreach}
     </TBODY>
     <TFOOT>
 	<TR>
-		<TD COLSPAN="2" ALIGN="RIGHT">
-			<IMG src="img/info2.gif" ALT="">
-			<B>{trans("Total:")}</B>
+		<TD COLSPAN="2" class="text-right">
+			<SPAN class="nobr bold"><IMG src="img/info2.gif" ALT=""> {trans("Total:")}</SPAN>
 		</TD>
-		<TD ALIGN="right" nowrap>
-			<B>{$listdata.sum|money_format}</B>
+		<TD class="text-right">
+			<SPAN class="nobr bold">{$listdata.sum|money_format}</SPAN>
 		</TD>
 		<TD COLSPAN="2"></TD>
-		<TD align="right">
-			<A href="?m=cashregadd">{trans("Add registry")} <IMG src="img/save.gif" alt=""></A>
+		<TD class="text-right">
+                        <SPAN class="nobr"><A href="?m=cashregadd">{trans("Add registry")} <IMG src="img/save.gif" alt=""></A></SPAN>
 		</TD>
 	</TR>
     </TFOOT>

--- a/templates/default/cashsourcelist.html
+++ b/templates/default/cashsourcelist.html
@@ -2,29 +2,34 @@
 <!-- $Id$ -->
 <H1>{$layout.pagetitle}</H1>
 <P><TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 97%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR>
-		<TD WIDTH="1%" nowrap>
-			<img src="img/isource.gif" alt=""><B>{trans("Name:")}</B>
-		</TD>
-		<TD WIDTH="1%" NOWRAP>
-			{trans("ID:")}
-		</TD>
-		<TD WIDTH="97%">
+		<TH scope="col">
+                        <SPAN class="nobr"><img src="img/isource.gif" alt=""> {trans("Name:")}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr lighter">{trans("ID:")}</SPAN>
+		</TH>
+		<TH scope="col" class="lighter">
 			{trans("Description:")}
-		</TD>
-		<TD WIDTH="1%" nowrap>
-			<A href="?m=cashsourceadd">{trans("Add source")} <img src="img/save.gif" alt=""></A>
-		</TD>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr lighter"><A href="?m=cashsourceadd">{trans("Add source")} <img src="img/save.gif" alt=""></A></SPAN>
+		</TH>
 	</TR>
     </THEAD>
     <TBODY>
 	{cycle values="light,lucid" print=false}
 	{foreach from=$sourcelist item=source}
-	<TR class="highlight {cycle}"  >
-		<TD onClick="return self.location.href='?m=cashsourceedit&id={$source.id}'" nowrap>
-			<IMG src="img/isource.gif" alt="">
-			<B>{$source.name}</B>
+	<TR class="highlight {cycle}">
+		<TD onClick="return self.location.href='?m=cashsourceedit&id={$source.id}'">
+                        <SPAN class="nobr bold"><IMG src="img/isource.gif" alt=""> {$source.name}</SPAN>
 		</TD>
 		<TD onClick="return self.location.href='?m=cashsourceedit&id={$source.id}'">
 			({$source.id|string_format:"%04d"})
@@ -32,25 +37,25 @@
 		<TD onClick="return self.location.href='?m=cashsourceedit&id={$source.id}'">
 			{$source.description}
 		</TD>
-		<TD align="right" NOWRAP>
+		<TD class="text-right">
+                        <SPAN class="nobr">
 			<A HREF="?m=cashsourcedel&id={$source.id}" OnClick="return confirmLink(this, '{t a=$source.name}Are you sure, you want to remove source \'$a\'?{/t}');"><IMG src="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 			<A HREF="?m=cashsourceedit&id={$source.id}"><IMG src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A>
+                        </SPAN>
 		</TD>
 	</TR>
 	{foreachelse}
 	<TR>
-		<TD colspan="4" align="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("There are no sources in database.")}<B></p>
-			<p>&nbsp;</p>
+		<TD colspan="4" class="empty-table">
+			{trans("There are no sources in database.")}
 		</TD>
 	</TR>
 	{/foreach}
     </TBODY>
     <TFOOT>
 	<TR>
-		<TD colspan="4" align="right">
-			<A href="?m=cashsourceadd">{trans("Add source")} <IMG src="img/save.gif" alt=""></A>
+		<TD colspan="4" class="text-right">
+                        <SPAN class="nobr"><A href="?m=cashsourceadd">{trans("Add source")} <IMG src="img/save.gif" alt=""></A></SPAN>
 		</TD>
 	</TR>
     </TFOOT>

--- a/templates/default/configlist.html
+++ b/templates/default/configlist.html
@@ -2,21 +2,27 @@
 <!--// $Id$ //-->
 <H1>{$layout.pagetitle}</H1>
 <P><TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 97%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR>
-		<TD style="width: 1%; white-space: nowrap;">
-			<IMG src="img/settings.gif" alt=""><A href="?m=configlist&o=var{if $listdata.direction eq "asc" && $listdata.order eq "var"},desc{/if}"> <span class="bold">{trans("Name:")}</span></A> {if $listdata.order eq "var"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<IMG src="img/empty.gif" alt="" width="16" height="16"><A href="?m=configlist&o=section{if $listdata.direction eq "asc" && $listdata.order eq "section"},desc{/if}"> {trans("Section:")}</A> {if $listdata.order eq "section"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD style="width: 1%; text-align: center;">
+		<TH scope="col">
+                        <SPAN class="nobr"><IMG src="img/settings.gif" alt=""><A href="?m=configlist&o=var{if $listdata.direction eq "asc" && $listdata.order eq "var"},desc{/if}"> <span class="bold">{trans("Name:")}</span></A> {if $listdata.order eq "var"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+                        <SPAN class="nobr"><IMG src="img/empty.gif" alt="" width="16" height="16"><A href="?m=configlist&o=section{if $listdata.direction eq "asc" && $listdata.order eq "section"},desc{/if}"> {trans("Section:")}</A> {if $listdata.order eq "section"}<IMG src="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-center">
 			{trans("Value:")}
-		</TD>
-		<TD style="width: 97%; text-align: center;">
+		</TH>
+		<TH scope="col" class="text-center">
 			{trans("Comment:")}
-		</TD>
-		<TD style="width: 1%; text-align: right; white-space: nowrap;">
-			<A href="?m=configadd{if $listdata.section}&section={$listdata.section}{/if}">{trans("Add option")} <IMG src="img/save.gif" alt=""> </A>
-		</TD>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr"><A href="?m=configadd{if $listdata.section}&section={$listdata.section}{/if}">{trans("Add option")} <IMG src="img/save.gif" alt=""></A></SPAN>
+		</TH>
 	</TR>
 	<TR>
 		<TD colspan="4">
@@ -24,7 +30,7 @@
 				<INPUT type="submit" class="hiddenbtn">
 				<INPUT type="HIDDEN" name="m" value="configlist">
 				<INPUT type="HIDDEN" name="page" value="1">
-				<span class="bold">{trans("Filter:")} </span> {trans("Section:")}
+				<SPAN class="bold">{trans("Filter:")} </SPAN> {trans("Section:")}
 				<SELECT size="1" name="s" OnChange="document.filter.submit();">
 					<OPTION value=""{if !$listdata.section} SELECTED{/if}>{trans("- all -")}</OPTION>
 					{foreach $sections as $section}
@@ -48,36 +54,34 @@
     <TBODY>
 	{cycle values="light,lucid" print=false}
 	{section name=configlist loop=$configlist start=$start max=$pagelimit}
-	<TR class="highlight {cycle}{if $configlist[configlist].disabled} blend{/if}"  >
-		<TD style="vertical-align: top; white-space: nowrap;" OnClick="return self.location.href='?m=configedit&id={$configlist[configlist].id}';">
-			<IMG src="img/settings.gif" alt=""><span class="bold"> {$configlist[configlist].var}</span><BR>
-			<IMG src="img/empty.gif" alt="" width="16" height="16"> [{$configlist[configlist].section}]
+	<TR class="highlight {cycle}{if $configlist[configlist].disabled} blend{/if}"s>
+		<TD OnClick="return self.location.href='?m=configedit&id={$configlist[configlist].id}';">
+			<SPAN class="nobr bold"><IMG src="img/settings.gif" alt=""> {$configlist[configlist].var}</SPAN><BR>
+                        <SPAN class="nobr"><IMG src="img/empty.gif" alt="" width="16" height="16"> [{$configlist[configlist].section}]</SPAN>
 		</TD>
-		<TD style="text-align: right; white-space: nowrap;" OnClick="return self.location.href='?m=configedit&id={$configlist[configlist].id}';">
+		<TD class="text-right" OnClick="return self.location.href='?m=configedit&id={$configlist[configlist].id}';">
 			{$configlist[configlist].value|escape}
 		</TD>
 		<TD OnClick="return self.location.href='?m=configedit&id={$configlist[configlist].id}';">
 			{$configlist[configlist].description|truncate:400:"..."}
-			{if $configlist[configlist].usercomment != ''}<BR><span class="bold">{trans("Comment:")}</span> {$configlist[configlist].usercomment|truncate:400:"..."}{/if}
+			{if $configlist[configlist].usercomment != ''}<BR><SPAN class="bold">{trans("Comment:")}</SPAN> {$configlist[configlist].usercomment|truncate:400:"..."}{/if}
 		</TD>
-		<TD style="text-align: right; white-space: nowrap;">
+		<TD class="text-right">
+                        <SPAN class="nobr">
 			<A href="?m=configedit&id={$configlist[configlist].id}&statuschange=1"><IMG src="img/wait.gif" alt="[ {if $configlist[configlist].disabled}{trans("Enable")}{else}{trans("Disable")}{/if} ]" title="[ {if $configlist[configlist].disabled}{trans("Enable")}{else}{trans("Disable")}{/if} ]"></A>
 			<A href="?m=configdel&id={$configlist[configlist].id}" OnClick="return confirmLink(this, '{t a=$configlist[configlist].var}Are you sure, you want to delete option \'$a\' from database?{/t}');"><IMG src="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 			<A href="?m=configedit&id={$configlist[configlist].id}"><IMG src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A>
+                        </SPAN>
 		</TD>
 	</TR>
 	{sectionelse}
 	<TR>
-		<TD colspan="4" style="text-align: center;">
-			<p>&nbsp;</p>
-			<p><span class="bold">
+		<TD colspan="4" class="empty-table">
 			    {if $listdata.search}
 			        {trans("No configuration options in database.")}
 			    {else}
 			        {trans("No configuration options in database.")} {t}Click <A href="?m=configload">here</A> to import them from lms.ini.{/t}
 			    {/if}
-			    </span></p>
-			<p>&nbsp;</p>
 		</TD>
 	</TR>
 	{/section}
@@ -91,7 +95,7 @@
 	</TR>
 	{/if}
 	<TR>
-		<TD colspan="4" style="text-align: right;">
+		<TD colspan="4" class="text-right">
 			<A href="?m=configadd{if $listdata.section}&section={$listdata.section}{/if}">{trans("Add option")} <IMG src="img/save.gif" alt=""></A>
 		</TD>
 	</TR>

--- a/templates/default/customergrouplist.html
+++ b/templates/default/customergrouplist.html
@@ -2,39 +2,45 @@
 <!--// $Id$ //-->
 <H1>{$layout.pagetitle}</H1>
 <TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 97%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR>
-		<TD WIDTH="97%">
-			<IMG SRC="img/group.gif" ALT="">&nbsp;<B>{trans("Name:")}</B><BR>
-			<IMG SRC="img/info1.gif" ALT="">&nbsp;{trans("Description:")}
-		</TD>
-		<TD WIDTH="1%" align="right">
+                <TH scope="col">
+                        <SPAN class="nobr"><IMG SRC="img/group.gif" ALT=""> {trans("Name:")}</SPAN><BR>
+                        <SPAN class="nobr lighter"><IMG SRC="img/info1.gif" ALT=""> {trans("Description:")}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right lighter">
 			{trans("ID:")}
-		</TD>
-		<TD WIDTH="1%" align="right">
+		</TH>
+                <TH scope="col" class="text-right lighter">
 			{trans("Members:")}
-		</TD>
-		<TD WIDTH="1%" ALIGN="RIGHT" nowrap>
-			<B>{t a=$listdata.total|default:"0"}Total: $a{/t}</B>
-		</TD>
+		</TH>
+		<TH scope="col" class="text-right">
+			<SPAN class="nobr">{t a=$listdata.total|default:"0"}Total: $a{/t}</SPAN>
+		</TH>
 	</TR>
     </THEAD>
     <TBODY>
 	{cycle values="light,lucid" print=false}
 	{section name=customergroups loop=$customergrouplist}
 	<TR class="highlight {cycle}"  >
-		<TD WIDTH="97%" onClick="return self.location.href='?m=customergroupinfo&id={$customergrouplist[customergroups].id}';">
+		<TD onClick="return self.location.href='?m=customergroupinfo&id={$customergrouplist[customergroups].id}';">
 			<IMG SRC="img/group.gif" ALT="">&nbsp;<B>{$customergrouplist[customergroups].name}</B><BR>
 			{if $customergrouplist[customergroups].description}<IMG SRC="img/info1.gif" ALT="">&nbsp;{$customergrouplist[customergroups].description}{/if}
 		</TD>
-		<TD WIDTH="1%" align="right" onClick="return self.location.href='?m=customergroupinfo&id={$customergrouplist[customergroups].id}';">
+		<TD class="text-right" onClick="return self.location.href='?m=customergroupinfo&id={$customergrouplist[customergroups].id}';">
 			({$customergrouplist[customergroups].id|string_format:"%04d"})
 		</TD>
-		<TD WIDTH="1%" align="right" onClick="return self.location.href='?m=customergroupinfo&id={$customergrouplist[customergroups].id}';">
+		<TD class="text-right" onClick="return self.location.href='?m=customergroupinfo&id={$customergrouplist[customergroups].id}';">
 			{$customergrouplist[customergroups].customerscount} 
 		</TD>
-		<TD WIDTH="1%" ALIGN="right">
-			<NOBR>
+		<TD class="text-right">
+			<SPAN class="nobr">
 			{if $customergrouplist[customergroups].customers}
 				<A HREF="javascript:alert('{trans("Group with members cannot be deleted!")}');">
 			{else}
@@ -42,28 +48,26 @@
 			{/if}<IMG SRC="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 				<A HREF="?m=customergroupedit&id={$customergrouplist[customergroups].id}"><IMG src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A>
 				<A HREF="?m=customergroupinfo&id={$customergrouplist[customergroups].id}"><IMG src="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A>
-			</NOBR>
+			</SPAN>
 		</TD>
 	</TR>
 	{sectionelse}
 	<TR>
-		<TD COLSPAN="4" ALIGN="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("There are no such groups in database.")}</B></p>
-			<p>&nbsp;</p>
+		<TD COLSPAN="4" class="empty-table">
+			{trans("There are no such groups in database.")}
 		</TD>
 	</TR>
 	{/section}
     </TBODY>
     <TFOOT>
 	<TR>
-		<TD COLSPAN="2" WIDTH="98%" ALIGN="right">
-			<IMG SRC="img/info2.gif" ALT="">&nbsp;<B>{trans("Total:")}</B>
+		<TD COLSPAN="2" class="text-right">
+                        <SPAN class="nobr bold"><IMG SRC="img/info2.gif" ALT=""> {trans("Total:")}</SPAN>
 		</TD>
-		<TD WIDTH="1%" ALIGN="right" NOWRAP>
-			<B>{$listdata.totalcount|default:"0"} </B>
+		<TD class="text-right">
+			<SPAN class="bold">{$listdata.totalcount|default:"0"}</SPAN>
 		</TD>
-		<TD WIDTH="1%">
+		<TD>
 			&nbsp;
 		</TD>
 	</TR>

--- a/templates/default/customerlist.html
+++ b/templates/default/customerlist.html
@@ -3,25 +3,31 @@
 <H1>{$layout.pagetitle}</H1>
 
 <TABLE class="lmsbox">
+        <COLGROUP>
+                <COL style="width: 97%;">
+                <COL style="width: 1%;">
+                <COL style="width: 1%;">
+                <COL style="width: 1%;">
+        </COLGROUP>
         <THEAD>
 	<TR {tip text="Click on column name to change sorting order"}>
-		<TD width="97%">
-			<img src="img/customer.gif" ALT="">&nbsp;<a href="?m={$layout.module}&s={$listdata.state}&o=customername{if $listdata.direction eq "asc" && $listdata.order eq "customername"},desc{/if}">{trans("First/last or Company name")}</A></B> {if $listdata.order eq "customername"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<img src="img/home.gif" ALT="">&nbsp;<a href="?m={$layout.module}&s={$listdata.state}&o=address{if $listdata.direction eq "asc" && $listdata.order eq "address"},desc{/if}">{trans("Address:")}</A> {if $listdata.order eq "address"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD align="right" width="1%" VALIGN="top" NOWRAP>
+                <TH scope="col">
+                        <SPAN class="nobr"><img src="img/customer.gif" ALT=""> <a href="?m={$layout.module}&s={$listdata.state}&o=customername{if $listdata.direction eq "asc" && $listdata.order eq "customername"},desc{/if}">{trans("First/last or Company name")}</A> {if $listdata.order eq "customername"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+                        <SPAN class="nobr"><img src="img/home.gif" ALT=""> <a href="?m={$layout.module}&s={$listdata.state}&o=address{if $listdata.direction eq "asc" && $listdata.order eq "address"},desc{/if}">{trans("Address:")}</A> {if $listdata.order eq "address"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
 			<a href="?m={$layout.module}&s={$listdata.state}&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("ID:")}</A></B> {if $listdata.order eq "id"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
 			{trans("Services:")}
-		</TD>
-		<TD width="1%" ALIGN="right" VALIGN="TOP" NOWRAP>
+		</TH>
+		<TH scope="col" class="text-right">
 		{if !check_conf('privileges.hide_finances')}
 			<a href="?m={$layout.module}&s={$listdata.state}&o=balance{if $listdata.direction eq "asc" && $listdata.order eq "balance"},desc{/if}">{trans("Balance:")}</A>&nbsp;{if $listdata.order eq "balance"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
 			<a href="?m={$layout.module}&s={$listdata.state}&o=tariff{if $listdata.direction eq "asc" && $listdata.order eq "tariff"},desc{/if}">{trans("Subscription:")}</A>&nbsp;{if $listdata.order eq "tariff"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
 		{/if}
-		</TD>
-		<TD width="1%" align="right">
-			<NOBR><B>{t a=$listdata.total}Total: $a{/t}</B></NOBR>
-		</TD>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr">{t a=$listdata.total}Total: $a{/t}</SPAN>
+		</TH>
 	</TR>
 	<TR>
 		<TD colspan="4">
@@ -91,23 +97,26 @@
 	{cycle values="light,lucid" print=false}
 	{section name=customerlist loop=$customerlist start=$start max=$pagelimit}
 	<TR class="highlight {cycle}{if $customerlist[customerlist].account && !$customerlist[customerlist].nodeac} blend{/if}"  >
-		<TD onClick="return self.location.href='?m=customerinfo&id={$customerlist[customerlist].id}';" valign="top">
+		<TD onClick="return self.location.href='?m=customerinfo&id={$customerlist[customerlist].id}';">
 			<IMG src="img/{if $customerlist[customerlist].status eq 1}unk{/if}{if $customerlist[customerlist].status eq 2}wait{/if}{if $customerlist[customerlist].status eq 3}customer{/if}.gif" alt="">{if $customerlist[customerlist].info}&nbsp;<img src="img/info1.gif" alt="" {tip text=$customerlist[customerlist].info}>{/if}<A name="{$customerlist[customerlist].id}" {tip a=$customerlist[customerlist].id dynpopup='?m=customerinfoshort&id=$a'}>&nbsp;<B>{$customerlist[customerlist].customername|escape}</B></A><BR>
 			<IMG src="img/home.gif" alt="">&nbsp;{$customerlist[customerlist].address}{if $customerlist[customerlist].city neq ""},{/if} {$customerlist[customerlist].zip} {$customerlist[customerlist].city}{if $customerlist[customerlist].country neq ""}, {t}{$customerlist[customerlist].country}{/t}{/if}
 		</TD>
-		<TD valign="top" align="right">
-			({$customerlist[customerlist].id|string_format:"%04d"})<BR>
+		<TD class="text-right">
+			({$customerlist[customerlist].id|string_format:"%04d"})
+                        <BR>
 			{if $customerlist[customerlist].account}
-				<IMG SRC="img/node{if !$customerlist[customerlist].online}_off{/if}.gif" ALT="" {tip a=$customerlist[customerlist].id dynpopup='?m=nodelistshort&id=$a' sticky=1}></A>
+                        <IMG SRC="img/node{if !$customerlist[customerlist].online}_off{/if}.gif" ALT="" {tip a=$customerlist[customerlist].id dynpopup='?m=nodelistshort&id=$a' sticky=1}>
 			{/if}
 		</TD>
-		<TD align="right" valign="top" NOWRAP>
+		<TD class="text-right">
 			{if !check_conf('privileges.hide_finances')}
-			<NOBR><IMG src="img/empty.gif" width="1" height="16" ALT="">{if $customerlist[customerlist].balance < 0}<font class="alert">{/if}{$customerlist[customerlist].balance|money_format}{if $customerlist[customerlist].balance < 0}</FONT>{/if}<BR><IMG src="img/empty.gif" width="1" height="16" ALT=""><FONT CLASS="blend">{$customerlist[customerlist].tariffvalue|money_format}</FONT></NOBR>
+			<SPAN class="nobr{if $customerlist[customerlist].balance < 0} alert{/if}"> <IMG src="img/empty.gif" width="1" height="16" ALT=""> {$customerlist[customerlist].balance|money_format}</SPAN>
+                        <BR>
+                        <SPAN class="nobr blend"><IMG src="img/empty.gif" width="1" height="16" ALT="">{$customerlist[customerlist].tariffvalue|money_format}</SPAN>
 			{/if}
 		</TD>
-		<TD align="right">
-			<NOBR>
+		<TD class="text-right">
+			<SPAN class="nobr">
 			{if !check_conf('privileges.hide_finances')}
 				{if $customerlist[customerlist].balance < 0}
 					<A HREF="?m=customerbalanceok&id={$customerlist[customerlist].id}" OnClick="return confirmLink(this, '{t a=$customerlist[customerlist].customername|escape:"javascript"|escape:"html"}Are you sure, you want to account ALL debts of customer \'$a\'?{/t}');"><IMG src="img/pay.gif" alt="[ {trans("Account")} ]" title="[ {trans("Account")} ]"></A>
@@ -144,15 +153,13 @@
 			<A href="?m=customeredit&id={$customerlist[customerlist].id}"><IMG src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A> 
 			{/if}
 			<A href="?m=customerinfo&id={$customerlist[customerlist].id}"><IMG src="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A>
-			</NOBR>
+			</SPAN>
 		</TD>
 	</TR>
 	{sectionelse}
 	<TR>
-		<TD colspan="4" align="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("No such customers matching search criteria or list is empty.")}</B></p>
-			<p>&nbsp;</p>
+		<TD colspan="4" class="empty-table">
+			{trans("No such customers matching search criteria or list is empty.")}
 		</TD>
 	</TR>
 	{/section}
@@ -166,22 +173,22 @@
         </TR>
         {/if}
         <TR>
-                <TD align="right">
+                <TD class="text-right">
                         &nbsp;
                 </TD>
-                <TD align="right">
+                <TD class="text-right bold">
                         {if !check_conf('privileges.hide_finances') && !check_conf('privileges.hide_summaries')}
-                        <B>{trans("Outstandings")}:<BR>
-                        {trans("Overcharges")}:</B>
+                        {trans("Outstandings")}:<BR>
+                        {trans("Overcharges")}:
                         {/if}
                 </TD>
-                <TD align="right" nowrap>
+                <TD class="text-right bold">
                         {if !check_conf('privileges.hide_finances') && !check_conf('privileges.hide_summaries')}
-                        <B>{$listdata.below|money_format}<BR>
-                        {$listdata.over|money_format}</B>
+                        <SPAN class="nobr">{$listdata.below|money_format}</SPAN><BR>
+                        <SPAN class="nobr">{$listdata.over|money_format}</SPAN>
                         {/if}
                 </TD>
-                <TD align="right" valign="top">
+                <TD class="text-right">
                         <B>{trans("Total:")} {$listdata.total}</B>
                 </TD>
         </TR>

--- a/templates/default/dblist.html
+++ b/templates/default/dblist.html
@@ -21,54 +21,57 @@
 <FORM METHOD="POST" ACTION="?m=dbnew" name="statsitem">
 <INPUT type="submit" class="hiddenbtn">
 <TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 98%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
         <TR>
-                <TD width="98%">
-                        <IMG src="img/time.gif" alt=""> <B>{trans("Creation time:")}</B>
-                </TD>
-                <TD width="1%" nowrap>
-                        <IMG src="img/plain.gif" alt=""> {trans("Size:")}
-                </TD>
-                <TD width="1%" align="right" nowrap>
-                        <IMG src="img/empty.gif" alt="" height="16" width="1"><B> {t a=$dblist.total}Total: $a{/t}</B>&nbsp;
-                </TD>
+                <TH scope="col">
+                        <SPAN class="nobr"><IMG src="img/time.gif" alt=""> {trans("Creation time:")}</SPAN>
+                </TH>
+                <TH scope="col" class="text-right">
+                        <SPAN class="nobr"><IMG src="img/plain.gif" alt=""> {trans("Size:")}</SPAN>
+                </TH>
+                <TH scope="col" class="text-right">
+                        <SPAN class="nobr"><IMG src="img/empty.gif" alt="" height="16" width="1"> {t a=$dblist.total}Total: $a{/t}</SPAN>
+                </TH>
         </TR>
     </THEAD>
     <TBODY>
         {cycle values="light,lucid" print=false}
         {section name=dblist loop=$dblist.time}
         <TR class="highlight {cycle}{if $dblist.dbv[dblist] != $layout.dbschversion} blend{/if}"  >
-                <TD width="98%" onClick="return self.location.href='?m=dbview&db={$dblist.name[dblist]}&file=/lms-{$dblist.time[dblist]|date_format:"%Y%m%d-%H%M%S"}.sql{if $dblist.type[dblist]=="gz"}.gz{elseif $dblist.type[dblist]=="plain"}{/if}';">
+                <TD onClick="return self.location.href='?m=dbview&db={$dblist.name[dblist]}&file=/lms-{$dblist.time[dblist]|date_format:"%Y%m%d-%H%M%S"}.sql{if $dblist.type[dblist]=="gz"}.gz{elseif $dblist.type[dblist]=="plain"}{/if}';">
                         <IMG src="img/time.gif" alt=""> {$dblist.time[dblist]|date_format:"%x %X (%A)"}
                 </TD>
-                <TD width="1%" align="right" onClick="return self.location.href='?m=dbview&db={$dblist.name[dblist]}&file=/lms-{$dblist.time[dblist]|date_format:"%Y%m%d-%H%M%S"}.sql{if $dblist.type[dblist]=="gz"}.gz{elseif $dblist.type[dblist]=="plain"}{/if}';" nowrap>
+                <TD class="text-right" onClick="return self.location.href='?m=dbview&db={$dblist.name[dblist]}&file=/lms-{$dblist.time[dblist]|date_format:"%Y%m%d-%H%M%S"}.sql{if $dblist.type[dblist]=="gz"}.gz{elseif $dblist.type[dblist]=="plain"}{/if}';" nowrap>
                         {if $dblist.type[dblist]=="gz"}
                                 <IMG src="img/zipped.gif" alt="">
                         {else}
                                 <IMG src="img/plain.gif" alt="">
                         {/if} {$dblist.size[dblist]} {trans("bytes")}
                 </TD>
-                <TD width="1%" align="right" nowrap> 
-                        <nobr>
+                <TD class="text-right">
+                        <SPAN class="nobr">
                         {if $dblist.dbv[dblist] == $layout.dbschversion}
                         <a href="?m=dbrecover&db={$dblist.name[dblist]}{if $dblist.type[dblist]=="gz"}&gz=1{elseif $dblist.type[dblist]=="plain"}{/if}" onClick="return confirmLink(this, '{trans("Are you sure, you want to restore this database backup?")}\n{trans("WARNING! It will backup current database content automatically")}')"><IMG src="img/recover.gif" alt="[ {trans("Restore")} ]" title="[ {trans("Restore")} ]"></A>
                         {/if}
                         <a href="?m=dbdel&db={$dblist.name[dblist]}" onClick="return confirmLink(this, '{trans("Are you sure, you want to delete this database backup?")}')"><IMG src="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
                         <A href="?m=dbview&db={$dblist.name[dblist]}&file=/lms-{$dblist.time[dblist]|date_format:"%Y%m%d-%H%M%S"}.sql{if $dblist.type[dblist]=="gz"}.gz{elseif $dblist.type[dblist]=="plain"}{/if}"><img src="img/save.gif" alt="[ {trans("Save")} ]" title="[ {trans("Save")} ]"></A>
-                        </nobr>
+                        </SPAN>
                 </TD>
         </TR>	
         {sectionelse}
         <TR>
-                <TD colspan="3" width="100%" align="center">
-                        <p>&nbsp;</p>
-                        <p><B>{trans("Database backups currently not found.")}</B></p>
-                        <p>&nbsp;</p>
+                <TD colspan="3" class="empty-table">
+                    {trans("Database backups currently not found.")}
                 </TD>
         </TR>
         {/section}
         <TR>
-                <TD colspan="3" width="100%" align="right">
+                <TD colspan="3" class="text-right">
                         <INPUT type="checkbox" name="attachstats" id="attachstats"> <label for="attachstats">{trans("Attach stats")}</label>&nbsp;
                         {trans("Create new")}
                         <A HREF="javascript:createBackup(false);">{trans("uncompressed")} <img src="img/dbnew.gif" alt=""></A> / 

--- a/templates/default/nodelist.html
+++ b/templates/default/nodelist.html
@@ -3,64 +3,70 @@
 <H1>{$layout.pagetitle}</H1>
 {$lastonline_limit = get_conf('phpui.lastonline_limit')}
 <TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 97%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+        <COL style="width: 1%;">
+    </COLGROUP>
     <THEAD>
 	<TR {tip text="Click on column name to change sorting order"}>
-		<TD width="97%">
-			<img src="img/node.gif" ALT=""> <A href="?m=nodelist&o=name{if $listdata.direction eq "asc" && $listdata.order eq "name"},desc{/if}"><B>{trans("Name:")}</B></A>{if $listdata.order eq "name"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<img src="img/customer.gif" ALT=""> <A href="?m=nodelist&o=owner{if $listdata.direction eq "asc" && $listdata.order eq "owner"},desc{/if}">{trans("Customer:")}</A>{if $listdata.order eq "owner"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD align="right" valign="top" width="1%" nowrap>
-			<img src="img/empty.gif" ALT="" width="1" height="16"><A href="?m=nodelist&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("Node ID:")}</A>{if $listdata.order eq "id"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<img src="img/empty.gif" ALT="" width="1" height="16"><A href="?m=nodelist&o=ownerid{if $listdata.direction eq "asc" && $listdata.order eq "ownerid"},desc{/if}">{trans("Customer ID:")}</A>{if $listdata.order eq "ownerid"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="1%" nowrap>
-			<img src="img/ip.gif" ALT="">&nbsp;<A href="?m=nodelist&o=ip{if $listdata.direction eq "asc" && $listdata.order eq "ip"},desc{/if}">{trans("IP address:")}</A>{if $listdata.order eq "ip"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<A href="?m=nodelist&o=ip_pub{if $listdata.direction eq "asc" && $listdata.order eq "ip_pub"},desc{/if}">({trans("Pub. IP address:")})</A> {if $listdata.order eq "ip_pub"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<BR>
-			<img src="img/mac.gif" ALT="">&nbsp;<A href="?m=nodelist&o=mac{if $listdata.direction eq "asc" && $listdata.order eq "mac"},desc{/if}">{trans("MAC address:")}</A>{if $listdata.order eq "mac"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}
-		</TD>
-		<TD width="1%" align="right">
-			<NOBR><B>{t a=$listdata.total}Total: $a{/t}</B></NOBR>
-		</TD>
+		<TH scope="col">
+                        <SPAN class="nobr"><img src="img/node.gif" ALT=""> <A href="?m=nodelist&o=name{if $listdata.direction eq "asc" && $listdata.order eq "name"},desc{/if}">{trans("Name:")}</A>{if $listdata.order eq "name"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+			<SPAN class="nobr lighter"><img src="img/customer.gif" ALT=""> <A href="?m=nodelist&o=owner{if $listdata.direction eq "asc" && $listdata.order eq "owner"},desc{/if}">{trans("Customer:")}</A>{if $listdata.order eq "owner"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr lighter"><img src="img/empty.gif" ALT="" width="1" height="16"><A href="?m=nodelist&o=id{if $listdata.direction eq "asc" && $listdata.order eq "id"},desc{/if}">{trans("Node ID:")}</A>{if $listdata.order eq "id"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+                        <SPAN class="nobr lighter"><img src="img/empty.gif" ALT="" width="1" height="16"><A href="?m=nodelist&o=ownerid{if $listdata.direction eq "asc" && $listdata.order eq "ownerid"},desc{/if}">{trans("Customer ID:")}</A>{if $listdata.order eq "ownerid"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
+                        <SPAN class="nobr lighter"><img src="img/ip.gif" ALT=""> <A href="?m=nodelist&o=ip{if $listdata.direction eq "asc" && $listdata.order eq "ip"},desc{/if}">{trans("IP address:")}</A>{if $listdata.order eq "ip"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}<A href="?m=nodelist&o=ip_pub{if $listdata.direction eq "asc" && $listdata.order eq "ip_pub"},desc{/if}">({trans("Pub. IP address:")})</A> {if $listdata.order eq "ip_pub"}<IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN><BR>
+                        <SPAN class="nobr lighter"><img src="img/mac.gif" ALT=""> <A href="?m=nodelist&o=mac{if $listdata.direction eq "asc" && $listdata.order eq "mac"},desc{/if}">{trans("MAC address:")}</A>{if $listdata.order eq "mac"} <IMG SRC="img/{if $listdata.direction eq "desc"}asc{else}desc{/if}_order.gif" alt="">{/if}</SPAN>
+		</TH>
+		<TH scope="col" class="text-right">
+			<SPAN class="nobr">{t a=$listdata.total}Total: $a{/t}</SPAN>
+		</TH>
 	</TR>
-	<TR class="ftop">
+	<TR>
 		<TD colspan="4">
 			<FORM METHOD="GET" ACTION="?m={$layout.module}" NAME="choosefilter">
 				<INPUT type="submit" class="hiddenbtn">
 				<INPUT TYPE="HIDDEN" NAME="m" VALUE="nodelist">
 				<INPUT TYPE="HIDDEN" NAME="page" VALUE="1">
-				<B>{trans("Filter:")}</B> 
-				<NOBR>{trans("Status:")}
+				<SPAN class="bold">{trans("Filter:")}</SPAN> 
+				<SPAN class="nobr">{trans("Status:")}
 				<SELECT SIZE="1" NAME="s" ONCHANGE="document.choosefilter.submit();">
 					<OPTION VALUE="0"{if $listdata.state eq 0} SELECTED{/if}>{trans("- all -")}</OPTION>
 					<OPTION VALUE="1"{if $listdata.state eq 1} SELECTED{/if}>{trans("connected<!plural:item>")}</OPTION>
 					<OPTION VALUE="2"{if $listdata.state eq 2} SELECTED{/if}>{trans("disconnected<!plural:item>")}</OPTION>
 					<OPTION VALUE="3"{if $listdata.state eq 3} SELECTED{/if}>{trans("online")}</OPTION>
-				</SELECT></NOBR>&nbsp;
-				<NOBR>{trans("Network:")}
+				</SELECT></SPAN>
+				<SPAN class="nobr">{trans("Network:")}
 				<SELECT SIZE="1" NAME="n" ONCHANGE="document.choosefilter.submit();">
 					<OPTION value="0" {if !$listdata.network} SELECTED {/if}>{trans("- all networks -")}</OPTION>
 					{section name=networks loop=$networks}
 					<OPTION value="{$networks[networks].id}" {if $listdata.network eq $networks[networks].id} SELECTED {/if}>{$networks[networks].name|truncate:30:"...":true}</OPTION>
 					{/section}
-				</SELECT></NOBR>&nbsp;
-				<NOBR>{trans("Group:")}
+				</SELECT></SPAN>
+				<SPAN class="nobr">{trans("Group:")}
 				<SELECT SIZE="1" NAME="ng" ONCHANGE="document.choosefilter.submit();">
 					<OPTION value="" {if !$listdata.nodegroup} SELECTED {/if}>{trans("- all groups -")}</OPTION>
 					{foreach from=$nodegroups item=nodegroup}
 					<OPTION value="{$nodegroup.id}" {if $listdata.nodegroup eq $nodegroup.id} SELECTED {/if}>{$nodegroup.name|truncate:30:"...":true}</OPTION>
 					{/foreach}
-				</SELECT></NOBR>&nbsp;
-				<NOBR>{trans("Customers Group:")}
+				</SELECT></SPAN>
+				<SPAN class="nobr">{trans("Customers Group:")}
 				<SELECT SIZE="1" NAME="g" ONCHANGE="document.choosefilter.submit();">
 					<OPTION value="" {if !$listdata.customergroup} SELECTED {/if}>{trans("- all groups -")}</OPTION>
 					{section name=customergroups loop=$customergroups}
 					<OPTION value="{$customergroups[customergroups].id}" {if $listdata.customergroup eq $customergroups[customergroups].id} SELECTED {/if}>{$customergroups[customergroups].name|truncate:30:"...":true}</OPTION>
 					{/section}
-				</SELECT></NOBR>
+				</SELECT></SPAN>
 			</FORM>
 		</TD>
 	</TR>
 	{if $listdata.total != 0}
-	<TR class="ftop">
+	<TR>
 		<TD class="pagination" colspan="4">
 			{include file="scroller.html" loop=$nodelist}
 		</TD>
@@ -71,8 +77,9 @@
 	{cycle values="light,lucid" print=false}
 	{section name=nodelist loop=$nodelist start=$start max=$pagelimit}
 	<TR class="highlight {cycle}{if ! $nodelist[nodelist].access} blend{/if}"  >
-		<TD width="95%" onClick="return self.location.href='?m=nodeinfo&id={$nodelist[nodelist].id}';">
-			<a name="{$nodelist[nodelist].id}">
+		<TD onClick="return self.location.href='?m=nodeinfo&id={$nodelist[nodelist].id}';">
+                        <SPAN class="bold nobr">
+			<A name="{$nodelist[nodelist].id}">
 			{if $nodelist[nodelist].lastonline}
 			    {if ($smarty.now-$nodelist[nodelist].lastonline) > $lastonline_limit}
 				<img src="img/node_off.gif" ALT="">
@@ -85,34 +92,32 @@
 			{if $nodelist[nodelist].info}
 			    <IMG src="img/info1.gif" alt="" {tip text=$nodelist[nodelist].info}>
 			{/if}
-			<B>{$nodelist[nodelist].name}</B></A><BR>
-			<img src="img/customer.gif" ALT="">&nbsp;<A href="?m=customerinfo&id={$nodelist[nodelist].ownerid}" {tip a=$nodelist[nodelist].ownerid dynpopup='?m=customerinfoshort&id=$a'}>{if ! $nodelist[nodelist].access}<font class="blend">{/if}{$nodelist[nodelist].owner|truncate:40:"...":true|replace:" ":"&nbsp;"}{if ! $nodelist[nodelist].access}</FONT>{/if}</A>
+                        {$nodelist[nodelist].name}</A></SPAN><BR>
+                        <SPAN class="nobr{if ! $nodelist[nodelist].access} blend{/if}"><img src="img/customer.gif" ALT=""> <A href="?m=customerinfo&id={$nodelist[nodelist].ownerid}" {tip a=$nodelist[nodelist].ownerid dynpopup='?m=customerinfoshort&id=$a'}>{$nodelist[nodelist].owner|truncate:40:"...":true|replace:" ":"&nbsp;"}</A></SPAN>
 		</TD>
-		<TD align="right" width="1%" onClick="return self.location.href='?m=nodeinfo&id={$nodelist[nodelist].id}';" valign="top">
-			<img src="img/empty.gif" ALT="" width="1" height="16">({$nodelist[nodelist].id|string_format:"%04d"})<BR>
-			<img src="img/empty.gif" ALT="" width="1" height="16"><font class="blend">({$nodelist[nodelist].ownerid|string_format:"%04d"})</font>
+		<TD class="text-right" onClick="return self.location.href='?m=nodeinfo&id={$nodelist[nodelist].id}';">
+                        <SPAN>({$nodelist[nodelist].id|string_format:"%04d"})</SPAN><BR>
+                        <SPAN class="blend">({$nodelist[nodelist].ownerid|string_format:"%04d"})</SPAN>
 		</TD>
-		<TD width="1%" onClick="return self.location.href='?m=nodeinfo&id={$nodelist[nodelist].id}';" valign="top" nowrap>
-			<img src="img/ip.gif" ALT="">&nbsp;{$nodelist[nodelist].ip} {if $nodelist[nodelist].ip_pub != "0.0.0.0"}({$nodelist[nodelist].ip_pub}){/if}<BR>
-			<nobr><img src="img/mac.gif" ALT="">&nbsp;{$nodelist[nodelist].mac|replace:",":"</nobr><BR><nobr><img src=\"img/mac.gif\" ALT=\"\">&nbsp;"}</nobr>
+		<TD onClick="return self.location.href='?m=nodeinfo&id={$nodelist[nodelist].id}';">
+                        <SPAN class="nobr"><img src="img/ip.gif" ALT=""> {$nodelist[nodelist].ip} {if $nodelist[nodelist].ip_pub != "0.0.0.0"}({$nodelist[nodelist].ip_pub}){/if}</SPAN><BR>
+			<SPAN class="nobr"><img src="img/mac.gif" ALT="">&nbsp;{$nodelist[nodelist].mac|replace:",":"</SPAN><BR><SPAN class=\"nobr\"><img src=\"img/mac.gif\" ALT=\"\"> "}</SPAN>
 		</TD>
-		<TD width="1%">
-			<nobr>
+		<TD>
+			<SPAN class="nobr">
 			<a href="?m=nodeset&id={$nodelist[nodelist].id}"><img src="img/{if ! $nodelist[nodelist].access}no{/if}access.gif" alt="[ {if ! $nodelist[nodelist].access}{trans("Connect")}{else}{trans("Disconnect")}{/if} ]" title="[ {if ! $nodelist[nodelist].access}{trans("Connect")}{else}{trans("Disconnect")}{/if} ]"></A>
                         <a href="?m=nodewarn&id={$nodelist[nodelist].id}"><img src="img/warning{if ! $nodelist[nodelist].warning}off{else}on{/if}.gif" alt="[ {if ! $nodelist[nodelist].warning}{trans("Enable notice")}{else}{trans("Disable notice")}{/if} ]" title="[ {if ! $nodelist[nodelist].warning}{trans("Enable notice")}{else}{trans("Disable notice")}{/if} ]"></A>
 			<a onClick="return confirmLink(this, '{t a=$nodelist[nodelist].name}Are you sure, you want to remove node \'$a\' from database?{/t}')" href="?m=nodedel&id={$nodelist[nodelist].id}"><img src="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 			<a href="?m=nodeedit&id={$nodelist[nodelist].id}"><img src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A>
 			<a href="?m=nodeinfo&id={$nodelist[nodelist].id}"><img src="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A>
-			</nobr>
+			</SPAN>
 		</TD>
 	</TR>
 	{if $nodelist[nodelist.index_next].ownerid eq $nodelist[nodelist].ownerid && $listdata.order eq "owner"}{cycle print=false}{/if}
 	{sectionelse}
 	<TR>
-		<TD colspan="4" align="center">
-			<p>&nbsp;</p>
-			<p><B>{trans("No such nodes in database.")}</b></p>
-			<p>&nbsp;</p>
+		<TD colspan="4" class="empty-table">
+			{trans("No such nodes in database.")}
 		</TD>
 	</TR>
 	{/section}
@@ -125,20 +130,16 @@
 		</TD>
 	</TR>
 	{/if}
-	<TR class="ftop">
-		<TD WIDTH="98%" COLSPAN="2" ALIGN="right">
-			<B>
-				{trans("Total:")}<BR>
-				{trans("Connected<!nodes>:")}<BR>
-				{trans("Disconnected:")}
-			</B>
+	<TR>
+		<TD COLSPAN="2" class="text-right bold">
+                        {trans("Total:")}<BR>
+                        {trans("Connected<!nodes>:")}<BR>
+                        {trans("Disconnected:")}
 		</TD>
-		<TD WIDTH="2%" COLSPAN="2" VALIGN="TOP">
-			<B>
-				{if $listdata.total}{$listdata.total}{else}0{/if}<BR>
-				{if $listdata.totalon}{$listdata.totalon}{else}0{/if}<BR>
-				{if $listdata.totaloff}{$listdata.totaloff}{else}0{/if}
-			</B>
+		<TD COLSPAN="2" class="text-right bold">
+                        {if $listdata.total}{$listdata.total}{else}0{/if}<BR>
+                        {if $listdata.totalon}{$listdata.totalon}{else}0{/if}<BR>
+                        {if $listdata.totaloff}{$listdata.totaloff}{else}0{/if}
 		</TD>				
 	</TR>
     </TFOOT>

--- a/templates/default/userlist.html
+++ b/templates/default/userlist.html
@@ -1,27 +1,35 @@
 {include file="header.html"}
 <!--// $Id$ //-->
 <H1>{$layout.pagetitle}</H1>
-<table class="lmsbox">
+<TABLE class="lmsbox">
+    <COLGROUP>
+        <COL style="width: 1%;">
+        <COL style="width: 92%">
+        <COL style="width: 2%">
+        <COL style="width: 2%">
+        <COL style="width: 2%">
+        <COL style="width: 1%">
+    </COLGROUP>
     <THEAD>
-	<TR>
-		<TD width="1%">
-			<NOBR><IMG SRC="img/users.gif" ALT=""> <B>{trans("Login:")}</B></NOBR>
-		</TD>
-		<TD width="92%">
-			<NOBR><IMG SRC="img/info2.gif" ALT=""> <B>{trans("First/last name:")}</B></NOBR>
-		</TD>
-		<td width="2%">
-		    <nobr><img src="img/calendar.gif" alt=""> <b>{trans("Active from:")} </b> </nobr>
-		</td>
-		<td width="2%">
-		    <nobr><img src="img/calendar.gif" alt=""> <b>{trans("Active to:")} </b> </nobr>
-		</td>
-		<TD width="2%" NOWRAP>
-			<IMG SRC="img/time.gif" ALT=""> <B>{trans("Last login:")}</B>
-		</TD>
-		<TD width="1%">
-			<NOBR><B>{trans("Total:")} {$userslist.total}</B></NOBR>
-		</TD>
+        <TR>
+                <TH scope="col">
+			<SPAN class="nobr"><IMG SRC="img/users.gif" ALT=""> {trans("Login:")}</SPAN>
+		</TH>
+		<TH scope="col">
+			<SPAN class="nobr"><IMG SRC="img/info2.gif" ALT=""> {trans("First/last name:")}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr"><img src="img/calendar.gif" alt=""> {trans("Active from:")}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr"><img src="img/calendar.gif" alt=""> {trans("Active to:")}</SPAN>
+		</TH>
+		<TH scope="col">
+                        <SPAN class="nobr"><IMG SRC="img/time.gif" ALT=""> {trans("Last login:")}</SPAN>
+		</TH>
+		<TH scope="col">
+			<SPAN class="nobr">{trans("Total:")} {$userslist.total}</SPAN>
+		</TH>
 	</TR>
     </THEAD>
     <TFOOT><TR><TD colspan="6"></TD></TR></TFOOT>
@@ -29,24 +37,24 @@
 	{cycle values="light,lucid" print=false}
 	{section name=userslist loop=$userslist}{if $userslist[userslist].id}
 	<TR class="highlight {cycle} {if !$userslist[userslist].access}blend{/if}"  >
-		<TD width="1%" onClick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
-			<NOBR><IMG SRC="img/users.gif" ALT=""> <B>{$userslist[userslist].login}</B></NOBR>
+		<TD onClick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
+			<SPAN class="nobr bold"><IMG SRC="img/users.gif" ALT=""> {$userslist[userslist].login}</SPAN>
 		</TD>
-		<TD width="92%" onClick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
-			<NOBR><IMG SRC="img/info2.gif" ALT=""> {$userslist[userslist].name}</NOBR>
+		<TD onClick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
+			<SPAN class="nobr"><IMG SRC="img/info2.gif" ALT=""> {$userslist[userslist].name}</SPAN>
 		</TD>
-		<td width="2%"  onclick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
-			<nobr><img src="img/calendar.gif" ALT=""> {$userslist[userslist].accessfrom}</nobr>
+		<td onclick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
+			<SPAN class="nobr"><img src="img/calendar.gif" ALT=""> {$userslist[userslist].accessfrom}</SPAN>
 		</td>
-		<td width="2%"  onclick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
-			<nobr><img src="img/calendar.gif" ALT=""> {$userslist[userslist].accessto}</nobr>
+		<td onclick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
+			<SPAN class="nobr"><img src="img/calendar.gif" ALT=""> {$userslist[userslist].accessto}</SPAN>
 		</td>
-		<TD width="1%" onClick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
-			<NOBR><IMG SRC="img/time.gif" ALT=""> {$userslist[userslist].lastlogin}
-			{$userslist[userslist].lastloginip} {if $userslist[userslist].lastloginip neq $userslist[userslist].lastloginhost}({$userslist[userslist].lastloginhost}){/if}</NOBR>
+		<TD onClick="return self.location.href='?m=userinfo&id={$userslist[userslist].id}';">
+			<SPAN class="nobr"><IMG SRC="img/time.gif" ALT=""> {$userslist[userslist].lastlogin}
+			{$userslist[userslist].lastloginip} {if $userslist[userslist].lastloginip neq $userslist[userslist].lastloginhost}({$userslist[userslist].lastloginhost}){/if}</SPAN>
 		</TD>
-		<TD width="1%" style="text-align:right;">
-			<nobr>
+		<TD class="text-right">
+			<SPAN class="nobr">
 			{if $layout.logid ne $userslist[userslist].id}
 			    {if !$userslist[userslist].access}
 				<a href="?m=useraccess&id={$userslist[userslist].id}&access=1"><img src="img/noaccess.gif" alt="[ {trans('Connect')} ]" title="[ {trans('Connect')} ]" border="0"></a>
@@ -58,6 +66,7 @@
 			{if $userslist[userslist].id neq $layout.logid}<a href="?m=userdel&id={$userslist[userslist].id}" onClick="return confirmLink(this, '{trans("Are you sure, you want to irreversibly delete that user account?")}');">{/if}<img src="img/delete.gif" alt="[ {trans("Delete")} ]" title="[ {trans("Delete")} ]"></A>
 			<a href="?m=useredit&id={$userslist[userslist].id}"><img src="img/edit.gif" alt="[ {trans("Edit")} ]" title="[ {trans("Edit")} ]"></A>
 			<a href="?m=userinfo&id={$userslist[userslist].id}"><img src="img/info.gif" alt="[ {trans("Info")} ]" title="[ {trans("Info")} ]"></A>
+                        </SPAN>
 		</TD>
 	</TR>
 	{/if}{/section}


### PR DESCRIPTION
Dodałem nowe klasy CSS odpowiedzialne za wygląd tekstu, łamanie linii.

Przerobiłem kilka tabel dodając sekcję COLGROUP w której definiuje szerokość poszczególnych kolumn. Usunąłem atrybuty width, nowrap, align, znaczniki B z tabel i zastąpiłem klasami CSS. Tam gdzie było to potrzebne otoczyłem tekst znacznikami SPAN.

Resztę przerobionych tabel będę dosyłał gdy tylko znajdę chwile czasu na ich dokończenie.
