### PR TITLE
fix 'PHP Strict Standards:  mktime(): You should be using the time() fun...

### DIFF
--- a/modules/eventedit.php
+++ b/modules/eventedit.php
@@ -88,7 +88,7 @@ if(isset($_POST['event']))
 
 		$DB->Execute('UPDATE events SET moddate=?, moduserid=? WHERE id=?',
 			array(
-				mktime(), 
+				time(), 
 				$AUTH->id,
 				$event['id']
 				));


### PR DESCRIPTION
...ction instead'

z http://php.net/manual/en/function.mktime.php

"As of PHP 5.1, when called with no arguments, mktime() throws an E_STRICT notice: use the time() function instead."
