### PR TITLE
Update documentadd.html

### DIFF
--- a/templates/default/documentadd.html
+++ b/templates/default/documentadd.html
@@ -159,7 +159,7 @@
 			<B>{trans("Template:")}
 		</TD>
 		<TD width="98%">
-			<SELECT SIZE="1" NAME="document[templ]" {tip text="Select template to generate new document if you haven't got prepared file" trigger="templ"} id="template" onchange="getplugin();">
+			<SELECT SIZE="1" NAME="document[templ]" {tip text="Select template to generate new document if you haven't got prepared file" trigger="templ"} id="templ" onchange="getplugin();">
 				<OPTION VALUE="">... {trans("select template")} ...</OPTION>
 				{foreach $docengines as $docengine}
 				<OPTION VALUE="{$docengine.name}"{if $document.templ==$docengine.name} SELECTED{/if}>{$docengine.title}</OPTION>


### PR DESCRIPTION
BUG
Nie pamiętało jakiego szablonu używaliśmy jeśli nastąpiło przeładowanie dodawanie.
W generatorze pamięta jakiego szablonu się używało chociaż poprawiana linijka jest bardzo podobna. (nie sprawdzałem dokładnie)
