### PR TITLE
Update smarty_install.sh

### DIFF
--- a/devel/smarty_install.sh
+++ b/devel/smarty_install.sh
@@ -18,8 +18,8 @@ echo "done."
 
 # merging
 echo -n "Merging... "
-mv Smarty-$SMARTYVER/libs/* Smarty/
-mv Smarty-$SMARTYVER/libs/plugins/* Smarty/plugins/
+cp -r Smarty-$SMARTYVER/libs/* Smarty/
+cp -r Smarty-$SMARTYVER/libs/plugins/* Smarty/plugins/
 echo "done."
 
 # cleanup


### PR DESCRIPTION
Taka zmiana spowoduje, że skrypt będzie potrafił również aktualizować Smarty, bo teraz przy próbie nadpisania starej wersji wyskakiwało: "mv: cannot move „Smarty-3.1.15/libs/plugins” do „Smarty/plugins”: Directory not empty."
