### PR TITLE
Błąd bazy przy logowaniu się do userpanela

### DIFF
--- a/userpanel/lib/Session.class.php
+++ b/userpanel/lib/Session.class.php
@@ -164,7 +164,8 @@ class Session {
 					}
 					else
 						$authinfo['enabled'] = 2;
-					
+
+					$authinfo['id'] = $authdata['id'];
 					$authinfo['failedlogindate'] = time();
 					$authinfo['failedloginip'] = $this->ip;
 					SetCustomerAuthInfo($authinfo);


### PR DESCRIPTION
Brak tej jednej linijki, powodował błąd bazy:

```
BŁĄD:  pusta wartość w kolumnie "customerid" narusza ograniczenie wymaganej wartości
SZCZEGÓŁY:  Niepoprawne ograniczenia wiersza (1326, null, 0, , 1382027490, 127.0.0.1, 2).
WYRAŻENIE:  INSERT INTO up_customers(customerid, lastlogindate, lastloginip, failedlogindate, failedloginip, enabled) VALUES (NULL, 0, '', 1382027490, '127.0.0.1', 2)
```

w przypadku gdy:
- klient pierwszy raz się loguje do userpanelu (nie ma swojego wiersza w tabeli up_customers),
- i podaje zły PIN przy logowaniu (błąd wyskoczy jeśli PIN będzie błędny ale będzie składać się z samych liczb, jeśli w PINie będą jakieś inne znaki oprócz liczb np. PIN="111a" to błąd nie wyskoczy).
