### PR TITLE
nowy rodzaj dokumentu

### DIFF
--- a/devel/smarty_install.sh
+++ b/devel/smarty_install.sh
@@ -3,7 +3,7 @@
 # Smarty templates library quick installation (with sources download)
 #
 
-SMARTYVER="3.1.17"
+SMARTYVER="3.1.15"
 
 cd ../lib
 # download


### PR DESCRIPTION
Zmiana służy przerzucenie nazwy billing do menu -> dokumenty jako opcja przy tworzeniu nowego dokumentu.
Jeżeli taki sposób zachowania zgodności dla DOC_OTHER nie wystarcza, to musiałbym przygotować aktualizację bazy by takowe wpisy przeniósł pod nowy numer.
