### PR TITLE
nowy rodzaj dokumentu

### DIFF
--- a/lib/definitions.php
+++ b/lib/definitions.php
@@ -83,35 +83,33 @@ define('DOC_DNOTE', 5);
 define('DOC_INVOICE_PRO',6);
 define('DOC_INVOICE_PURCHASE',7);
 
-//wartosc -10 jest zarezerwowana dla starego oznaczania DOC_OTHER
 define('DOC_CONTRACT', -1);
 define('DOC_ANNEX', -2);
 define('DOC_PROTOCOL', -3);
 define('DOC_ORDER', -4);
 define('DOC_SHEET', -5);
-define('DOC_OTHER', -255); //poprzednia wartosc -10
-define('DOC_BILLING', -11);
+define('DOC_OTHER', -128);
+define('DOC_BILLING',-10);
 
 $DOCTYPES = array(
-    DOC_BILLING		=>	trans('billing'),
-    DOC_INVOICE 	=>	trans('invoice'),
-    DOC_INVOICE_PRO	=>	trans('pro-forma invoice'),
-    DOC_INVOICE_PURCHASE =>	trans('purchase invoice'),
-    DOC_RECEIPT 	=>	trans('cash receipt'),
-    DOC_CNOTE	    =>	trans('credit note'), // faktura korygujaca
-//    DOC_CMEMO	    =>	trans('credit memo'), // nota korygujaca
-    DOC_DNOTE	    =>	trans('debit note'), // nota obciazeniowa/debetowa/odsetkowa
-    DOC_CONTRACT	=>	trans('contract'),
-    DOC_ANNEX	    =>	trans('annex'),
-    DOC_PROTOCOL	=>	trans('protocol'),
-    DOC_ORDER       =>	trans('order'),
-    DOC_SHEET       =>	trans('customer sheet'), // karta klienta 
-    -6  =>	trans('contract termination'),
-    -7  =>	trans('payments book'), // ksiazeczka oplat
-    -8  =>	trans('payment summons'), // wezwanie do zapłaty
-    -9	=>	trans('payment pre-summons'), // przedsądowe wezw. do zapłaty
-    DOC_OTHER       =>	trans('other'),
-    -10 =>	trans('other') //nie zmieniać, wartość -10 wpisana jest w bazie danych dla DOC_OTHER
+    DOC_BILLING         =>      trans('billing'),
+    DOC_INVOICE         =>      trans('invoice'),
+    DOC_INVOICE_PRO     =>      trans('pro-forma invoice'),
+    DOC_INVOICE_PURCHASE =>     trans('purchase invoice'),
+    DOC_RECEIPT         =>      trans('cash receipt'),
+    DOC_CNOTE       =>  trans('credit note'), // faktura korygujaca
+//    DOC_CMEMO     =>  trans('credit memo'), // nota korygujaca
+    DOC_DNOTE       =>  trans('debit note'), // nota obciazeniowa/debetowa/odsetkowa
+    DOC_CONTRACT        =>      trans('contract'),
+    DOC_ANNEX       =>  trans('annex'),
+    DOC_PROTOCOL        =>      trans('protocol'),
+    DOC_ORDER       =>  trans('order'),
+    DOC_SHEET       =>  trans('customer sheet'), // karta klienta
+    -6  =>      trans('contract termination'),
+    -7  =>      trans('payments book'), // ksiazeczka oplat
+    -8  =>      trans('payment summons'), // wezwanie do zapłaty
+    -9  =>      trans('payment pre-summons'), // przedsądowe wezw. do zapłaty
+    DOC_OTHER       =>  trans('other'),
 );
 
 // Guarantee periods

--- a/lib/upgradedb/mysql.2014040400.php
+++ b/lib/upgradedb/mysql.2014040400.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * LMS version 1.11-git
+ *
+ *  (C) Copyright 2001-2014 LMS Developers
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ */
+
+$DB->BeginTrans();
+
+$DB->Execute("UPDATE docrights SET doctype = ? WHERE doctype = ?", array('-128', '-10'));
+$DB->Execute("UPDATE documents SET type = ? WHERE type = ?", array('-128', '-10'));
+
+$DB->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2014040400', 'dbversion'));
+$DB->CommitTrans();
+
+?>

--- a/lib/upgradedb/postgres.2014040400.php
+++ b/lib/upgradedb/postgres.2014040400.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * LMS version 1.11-git
+ *
+ *  (C) Copyright 2001-2014 LMS Developers
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ */
+
+$DB->BeginTrans();
+
+$DB->Execute("UPDATE docrights SET doctype = ? WHERE doctype = ?", array('-128', '-10'));
+$DB->Execute("UPDATE documents SET type = ? WHERE type = ?", array('-128', '-10'));
+
+$DB->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2014040400', 'dbversion'));
+$DB->CommitTrans();
+
+?>


### PR DESCRIPTION
Zmiana służy przerzuceniu nazwy 'billing' do `menu -> dokumenty` przy tworzeniu nowego dokumentu.
Jeżeli taki sposób zachowanie zgodności dla `DOC_OTHER` nie wystarczy, to musiałbym przygotować aktualizację bazy danych by takowe wpisy przeniósł pod nowy numer.
