### PR TITLE
LMSPluginManager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "homepage": "http://lms.org.pl/",
     "license": "GPL-2.0",
     "require": {
-        
+        "phine/observer": "2.0",
+        "phine/exception": "1.0"
     },
     "require_dev": {
         "phpunit/phpunit": "4.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,129 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "b7fc8f28d750a91b425504bec98dc11c",
+    "packages": [
+        {
+            "name": "phine/exception",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phine/lib-exception.git",
+                "reference": "150c6b6090b2ebc53c60e87cb20c7f1287b7b68a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phine/lib-exception/zipball/150c6b6090b2ebc53c60e87cb20c7f1287b7b68a",
+                "reference": "150c6b6090b2ebc53c60e87cb20c7f1287b7b68a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "league/phpunit-coverage-listener": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Phine\\Exception": "src/lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Herrera",
+                    "email": "kevin@herrera.io",
+                    "homepage": "http://kevin.herrera.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP library for improving the use of exceptions.",
+            "homepage": "https://github.com/phine/lib-exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2013-08-27 17:43:25"
+        },
+        {
+            "name": "phine/observer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phine/lib-observer.git",
+                "reference": "4604ba839f5755ca42b746b924972d49bc50e984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phine/lib-observer/zipball/4604ba839f5755ca42b746b924972d49bc50e984",
+                "reference": "4604ba839f5755ca42b746b924972d49bc50e984",
+                "shasum": ""
+            },
+            "require": {
+                "phine/exception": "~1.0",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "league/phpunit-coverage-listener": "~1.0",
+                "phine/test": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Phine\\Observer": "src/lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Herrera",
+                    "email": "kevin@herrera.io",
+                    "homepage": "http://kevin.herrera.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP library that implements the observer pattern.",
+            "homepage": "https://github.com/phine/lib-observer",
+            "keywords": [
+                "observer"
+            ],
+            "time": "2013-12-06 22:22:01"
+        }
+    ],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": [
+
+    ],
+    "prefer-stable": false,
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
+}

--- a/index.php
+++ b/index.php
@@ -55,6 +55,8 @@ $CONFIG['directories']['backup_dir'] = (!isset($CONFIG['directories']['backup_di
 $CONFIG['directories']['config_templates_dir'] = (!isset($CONFIG['directories']['config_templates_dir']) ? $CONFIG['directories']['sys_dir'].'/config_templates' : $CONFIG['directories']['config_templates_dir']);
 $CONFIG['directories']['smarty_compile_dir'] = (!isset($CONFIG['directories']['smarty_compile_dir']) ? $CONFIG['directories']['sys_dir'].'/templates_c' : $CONFIG['directories']['smarty_compile_dir']);
 $CONFIG['directories']['smarty_templates_dir'] = (!isset($CONFIG['directories']['smarty_templates_dir']) ? $CONFIG['directories']['sys_dir'].'/templates' : $CONFIG['directories']['smarty_templates_dir']);
+$CONFIG['directories']['plugins_dir'] = (!isset($CONFIG['directories']['plugins_dir']) ? $CONFIG['directories']['sys_dir'].'/plugins' : $CONFIG['directories']['plugins_dir']);
+$CONFIG['directories']['vendor_dir'] = (!isset($CONFIG['directories']['vendor_dir']) ? $CONFIG['directories']['sys_dir'].'/vendor' : $CONFIG['directories']['vendor_dir']);
 
 define('SYS_DIR', $CONFIG['directories']['sys_dir']);
 define('LIB_DIR', $CONFIG['directories']['lib_dir']);
@@ -63,6 +65,8 @@ define('BACKUP_DIR', $CONFIG['directories']['backup_dir']);
 define('MODULES_DIR', $CONFIG['directories']['modules_dir']);
 define('SMARTY_COMPILE_DIR', $CONFIG['directories']['smarty_compile_dir']);
 define('SMARTY_TEMPLATES_DIR', $CONFIG['directories']['smarty_templates_dir']);
+define('PLUGINS_DIR', $CONFIG['directories']['plugins_dir']);
+define('VENDOR_DIR', $CONFIG['directories']['vendor_dir']);
 
 // Load autloader
 require_once(LIB_DIR.'/autoloader.php');
@@ -146,6 +150,9 @@ if ($SYSLOG)
 $LMS = new LMS($DB, $AUTH, $SYSLOG);
 $LMS->ui_lang = $_ui_language;
 $LMS->lang = $_language;
+
+$plugins_manager = new LMSPluginsManager();
+$LMS->setPluginsManager($plugins_manager);
 
 // Initialize Swekey class
 

--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -38,6 +38,7 @@ class LMS {
 	public $_version = '1.11-git'; // class version
 	public $_revision = '$Revision$';
 	private $mail_object = NULL;
+        protected $plugins_manager;
 
 	public function __construct(&$DB, &$AUTH, &$SYSLOG) { // class variables setting
 		$this->DB = &$DB;
@@ -133,6 +134,28 @@ class LMS {
 
 		return $vars;
 	}
+        
+        /**
+         * Sets plugin manager
+         * 
+         * @param LMSPluginsManager $plugins_manager Plugin manager
+         */
+        public function setPluginsManager(LMSPluginsManager $plugins_manager)
+        {
+            $this->plugins_manager = $plugins_manager;
+        }
+        
+        /**
+         * Executes hook
+         * 
+         * @param string $hook_name Hook name
+         * @param mixed $hook_data Hook data
+         * @return mixed Modfied hook data
+         */
+        public function executeHook($hook_name, $hook_data = null)
+        {
+            return $this->plugins_manager->executeHook($hook_name, $hook_data);
+        }
 
 	/*
 	 *  Database functions (backups)

--- a/lib/LMSPluginManager/LMSPluginsManager.php
+++ b/lib/LMSPluginManager/LMSPluginsManager.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ *  LMS version 1.11-git
+ *
+ *  Copyright (C) 2001-2013 LMS Developers
+ *
+ *  Please, see the doc/AUTHORS for more information about authors!
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ *  $Id$
+ */
+
+use Phine\Observer\SubjectInterface;
+use Phine\Observer\Subject;
+
+/**
+ * LMSPluginsManager
+ *
+ * @author Maciej Lew <maciej.lew.1987@gmail.com>
+ */
+class LMSPluginsManager extends Subject implements SubjectInterface
+{
+    protected $hook_name;
+    protected $hook_data;
+    
+    /**
+     * Loads plugins
+     * 
+     * @throws Exception Throws exception if plugin not found
+     */
+    public function __construct()
+    {
+        $plugins_config = ConfigHelper::getConfig('phpui.plugins');
+        if ($plugins_config) {
+            $plugins_tuples = explode(';', $plugins_config);
+            foreach ($plugins_tuples as $position => $plugin_tuple) {
+                list($plugin_name, $plugin_priority) = explode(":", $plugin_tuple);
+                if (!class_exists($plugin_name)) {
+                    throw new Exception("Unknown plugin $plugin_name at position $position");
+                }
+                if ($plugin_priority === null) {
+                    $plugin_priority = SubjectInterface::LAST_PRIORITY;
+                }
+                $this->registerObserver(new $plugin_name(), $plugin_priority);
+            }
+        }
+    }
+    
+    /**
+     * Executes hook
+     * 
+     * @param mixed $hook_name Hook name
+     * @param mixed $hook_data Hook data
+     * @return mixed Modified hook data
+     */
+    public function executeHook($hook_name, $hook_data = null)
+    {
+        $this->hook_name = $hook_name;
+        $this->hook_data = $hook_data;
+        $this->notifyObservers();
+        return $this->hook_data;
+    }
+    
+    /**
+     * Returns hook name
+     * 
+     * @return string Hook name
+     */
+    public function getHookName()
+    {
+        return $this->hook_name;
+    }
+    
+    /**
+     * Returns hook data
+     * 
+     * @return mixed Hook data
+     */
+    public function getHookData()
+    {
+        return $this->hook_data;
+    }
+    
+    /**
+     * Sets hook data
+     * 
+     * @param mixed $hook_data Hook data
+     */
+    public function setHookData($hook_data)
+    {
+        $this->hook_data = $hook_data;
+    }
+    
+}

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -59,74 +59,86 @@ if (!defined('CACHE_DIR')) {
  * @package LMS
  */
 function application_autoloader($class) {
-    
-        $base_classes = array(
-                'LMSDB_common' => 'LMSDB_common.class.php',
-                'LMSDB_driver_mysql' => 'LMSDB_driver_mysql.class.php',
-                'LMSDB_driver_mysqli' => 'LMSDB_driver_mysqli.class.php',
-                'LMSDB_driver_postgres' => 'LMSDB_driver_postgres.class.php',
-                'LMS' => 'LMS.class.php',
-                'Auth' => 'Auth.class.php',
-                'ExecStack' => 'ExecStack.class.php',
-                'Session' => 'Session.class.php',
-                'Sysinfo' => 'Sysinfo.class.php',
-                'TCPDFpl' => 'tcpdf.php',
-                'Smarty' => 'Smarty/Smarty.class.php',
-                'SmartyBC' => 'Smarty/SmartyBC.class.php',
-                'Cezpdf' => 'ezpdf/class.ezpdf.php',
-                'Cpdf' => 'ezpdf/class.pdf.php',
-                'HTML2PDF' => 'html2pdf/html2pdf.class.php',
-                'TCPDF' => 'tcpdf/tcpdf.php'
-        );
-        
-        if (array_key_exists($class, $base_classes)) {
-                require_once LIB_DIR . DIRECTORY_SEPARATOR . $base_classes[$class];
-        } else {
-                // set cache file path
-                $cache_file = CACHE_DIR . "/classpaths.cache";
-                // read cache
-                $path_cache = (file_exists($cache_file)) ? unserialize(file_get_contents($cache_file)) : array();
-                // create empty cache container if cache is empty
-                if (!is_array($path_cache)) {
-                        $path_cache = array();
-                }
 
-                // check if class path exists in cache
-                if (array_key_exists($class, $path_cache)) {
-                        // try to load file
-                        if (file_exists($path_cache[$class])) {
-                                require_once $path_cache[$class];
-                        }
-                } else {
-                        // try to find class file in LIB_DIR
-                        $directories = new RecursiveDirectoryIterator(LIB_DIR);
-                        $suspicious_file_names = array(
-                                $class.'.php',
-                                $class.'.class.php',
-                                strtolower($class).'.php',
-                                strtolower($class).'.class.php',
-                                strtoupper($class).'.php',
-                                strtoupper($class).'.class.php',
-                        );
-                        foreach (new RecursiveIteratorIterator($directories) as $file) {
-                                if (in_array($file->getFilename(), $suspicious_file_names)) {
-                                        // get class file path
-                                        $full_path = $file->getRealPath();
-                                        // store path in cache
-                                        $path_cache[$class] = $full_path;
-                                        // load class file
-                                        require_once $full_path;
-                                        break;
-                                }
-                        }
-                }
-                // serialize cache
-                $serialized_paths = serialize($path_cache);
-                // if cache changed save it
-                if ($serialized_paths != $path_cache) {
-                        file_put_contents($cache_file, $serialized_paths);
-                }
+    $namespace = explode('\\', $class);
+    
+    $class = $namespace[count($namespace) - 1];
+    
+    $base_classes = array(
+        'LMSDB_common' => 'LMSDB_common.class.php',
+        'LMSDB_driver_mysql' => 'LMSDB_driver_mysql.class.php',
+        'LMSDB_driver_mysqli' => 'LMSDB_driver_mysqli.class.php',
+        'LMSDB_driver_postgres' => 'LMSDB_driver_postgres.class.php',
+        'LMS' => 'LMS.class.php',
+        'Auth' => 'Auth.class.php',
+        'ExecStack' => 'ExecStack.class.php',
+        'Session' => 'Session.class.php',
+        'Sysinfo' => 'Sysinfo.class.php',
+        'TCPDFpl' => 'tcpdf.php',
+        'Smarty' => 'Smarty/Smarty.class.php',
+        'SmartyBC' => 'Smarty/SmartyBC.class.php',
+        'Cezpdf' => 'ezpdf/class.ezpdf.php',
+        'Cpdf' => 'ezpdf/class.pdf.php',
+        'HTML2PDF' => 'html2pdf/html2pdf.class.php',
+        'TCPDF' => 'tcpdf/tcpdf.php'
+    );
+
+    if (array_key_exists($class, $base_classes)) {
+        require_once LIB_DIR . DIRECTORY_SEPARATOR . $base_classes[$class];
+    } else {
+        // set cache file path
+        $cache_file = CACHE_DIR . "/classpaths.cache";
+        // read cache
+        $path_cache = (file_exists($cache_file)) ? unserialize(file_get_contents($cache_file)) : array();
+        // create empty cache container if cache is empty
+        if (!is_array($path_cache)) {
+            $path_cache = array();
         }
+
+        // check if class path exists in cache
+        if (array_key_exists($class, $path_cache)) {
+            // try to load file
+            if (file_exists($path_cache[$class])) {
+                require_once $path_cache[$class];
+            }
+        } else {
+            // try to find class file in LIB_DIR, PLUGINS_DIR and VENDOR_DIR
+            $suspicious_file_names = array(
+                $class . '.php',
+                $class . '.class.php',
+                strtolower($class) . '.php',
+                strtolower($class) . '.class.php',
+                strtoupper($class) . '.php',
+                strtoupper($class) . '.class.php',
+            );
+            $search_paths = array(LIB_DIR, PLUGINS_DIR);
+            $file_found = false;
+            foreach ($search_paths as $search_path) {
+                if ($file_found === true) {
+                    break;
+                }
+                $directories = new RecursiveDirectoryIterator($search_path);
+                foreach (new RecursiveIteratorIterator($directories) as $file) {
+                    if (in_array($file->getFilename(), $suspicious_file_names)) {
+                        // get class file path
+                        $full_path = $file->getRealPath();
+                        // store path in cache
+                        $path_cache[$class] = $full_path;
+                        // load class file
+                        require_once $full_path;
+                        $file_found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        // serialize cache
+        $serialized_paths = serialize($path_cache);
+        // if cache changed save it
+        if ($serialized_paths != $path_cache) {
+            file_put_contents($cache_file, $serialized_paths);
+        }
+    }
 }
 
 // register autoloader

--- a/lib/phine/exception/.gitignore
+++ b/lib/phine/exception/.gitignore
@@ -1,0 +1,6 @@
+/.idea/
+/coverage/
+/src/vendors/
+
+/*.iml
+/composer.lock

--- a/lib/phine/exception/.travis.yml
+++ b/lib/phine/exception/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+    - 5.3
+    - 5.4
+    - 5.5
+
+before_script:
+    - composer self-update
+    - composer install --dev --no-interaction --prefer-source
+
+script: phpunit

--- a/lib/phine/exception/CONTRIBUTING.md
+++ b/lib/phine/exception/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+Contributing
+============
+
+To contribute, please follow the [PSR-2][] guidelines.
+
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md

--- a/lib/phine/exception/LICENSE
+++ b/lib/phine/exception/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2013 Kevin Herrera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/phine/exception/README.md
+++ b/lib/phine/exception/README.md
@@ -1,0 +1,52 @@
+Exception
+=========
+
+[![Build Status][]](https://travis-ci.org/phine/lib-exception)
+[![Coverage Status][]](https://coveralls.io/r/phine/lib-exception)
+[![Latest Stable Version][]](https://packagist.org/packages/phine/exception)
+[![Total Downloads][]](https://packagist.org/packages/phine/exception)
+
+Adds functionality to the standard `Exception` class.
+
+- Create new exceptions based on `sprintf()` format.
+- Create new exceptions using the last error (`error_get_last()`).
+
+Usage
+-----
+
+```php
+use Phine\Exception\Exception;
+
+$exception = Exception::createUsingFormat(
+    'This is my %s message.',
+    'formatted',
+    $previousException
+);
+
+echo $undefined;
+
+$exception = Exception::createUsingLastError();
+```
+
+Requirement
+-----------
+
+- PHP >= 5.3.3
+
+Installation
+------------
+
+Via [Composer][]:
+
+    $ composer require "phine/exception=~1.0"
+
+License
+-------
+
+This library is available under the [MIT license](LICENSE).
+
+[Build Status]: https://travis-ci.org/phine/lib-exception.png?branch=master
+[Coverage Status]: https://coveralls.io/repos/phine/lib-exception/badge.png
+[Latest Stable Version]: https://poser.pugx.org/phine/exception/v/stable.png
+[Total Downloads]: https://poser.pugx.org/phine/exception/downloads.png
+[Composer]: http://getcomposer.org/

--- a/lib/phine/exception/composer.json
+++ b/lib/phine/exception/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "phine/exception",
+    "description": "A PHP library for improving the use of exceptions.",
+    "keywords": ["exception"],
+    "homepage": "https://github.com/phine/lib-exception",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Kevin Herrera",
+            "email": "kevin@herrera.io",
+            "homepage": "http://kevin.herrera.io"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/phine/lib-exception/issues"
+    },
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "require-dev": {
+        "league/phpunit-coverage-listener": "~1.0"
+    },
+    "autoload": {
+        "psr-0": {
+            "Phine\\Exception": "src/lib"
+        }
+    },
+    "config": {
+        "bin-dir": "bin",
+        "vendor-dir": "src/vendors"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
+}

--- a/lib/phine/exception/phpunit.xml.dist
+++ b/lib/phine/exception/phpunit.xml.dist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="src/vendors/autoload.php" colors="true" strict="true">
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src/lib/</directory>
+    </whitelist>
+  </filter>
+  <logging>
+    <log type="coverage-clover" target="/tmp/coverage.xml"/>
+    <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+  </logging>
+  <listeners>
+    <listener class="League\PHPUnitCoverageListener\Listener">
+      <arguments>
+        <array>
+          <element key="namespace">
+            <string>Phine\Exception</string>
+          </element>
+          <element key="repo_token">
+            <string>e5e5f9Os9ygGusWMAvrRRCEKO5cOVxruP</string>
+          </element>
+          <element key="target_url">
+            <string>https://coveralls.io/api/v1/jobs</string>
+          </element>
+          <element key="printer">
+            <object class="League\PHPUnitCoverageListener\Printer\StdOut"/>
+          </element>
+          <element key="hook">
+            <object class="League\PHPUnitCoverageListener\Hook\Travis"/>
+          </element>
+          <element key="coverage_dir">
+            <string>/tmp</string>
+          </element>
+        </array>
+      </arguments>
+    </listener>
+  </listeners>
+  <testsuites>
+    <testsuite name="Phine Exception Test Suite">
+      <directory phpVersion="5.3.3" phpVersionOperator=">=" suffix="Test.php">src/tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/lib/phine/exception/src/lib/Phine/Exception/Exception.php
+++ b/lib/phine/exception/src/lib/Phine/Exception/Exception.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Phine\Exception;
+
+/**
+ * Builds on the `Exception` class to add more features.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class Exception extends \Exception
+{
+    /**
+     * Creates a new exception using a formatted message.
+     *
+     * A new exception is created after formatting the given arguments using
+     * `vsprintf()`. If the last argument is an instance of the `Exception`
+     * class, it will be used as the `$previous` exception in the new one
+     * that is created.
+     *
+     * @param string     $format    The message format.
+     * @param mixed      $value,... A value to format.
+     * @param \Exception $previous  A previous exception.
+     *
+     * @return Exception The new exception.
+     */
+    public static function createUsingFormat($format)
+    {
+        $previous = null;
+
+        if (1 < func_num_args()) {
+            $args = array_slice(func_get_args(), 1);
+
+            // extract $previous exception
+            if (end($args) instanceof \Exception) {
+                $previous = array_pop($args);
+            }
+
+            if ($args) {
+                $format = vsprintf($format, $args);
+            }
+        }
+
+        return new static($format, 0, $previous);
+    }
+
+    /**
+     * Uses the last error message to create a new exception.
+     *
+     * A new exception will be created using the last error message, which is
+     * returned by the `error_get_last()` function. If no error message was
+     * generated, the `$default` message will be used. By default, that message
+     * is "(unknown error)".
+     *
+     * The message `$prefix` will be added to any message that is used. The
+     * prefix "My prefix: " with the error message "my error" will result in
+     * "My prefix: error message" being used as the exception message.
+     *
+     * @param string $prefix  The message prefix.
+     * @param string $default The default message.
+     *
+     * @return Exception The new exception.
+     */
+    public static function createUsingLastError (
+        $prefix = null,
+        $default = '(unknown error)'
+    ) {
+        if (null === ($error = error_get_last())) {
+            $error = array('message' => $default);
+        }
+
+        return new static($prefix . $error['message']);
+    }
+}

--- a/lib/phine/exception/src/tests/Phine/Exception/Tests/ExceptionTest.php
+++ b/lib/phine/exception/src/tests/Phine/Exception/Tests/ExceptionTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Phine\Exception\Tests;
+
+use Phine\Exception\Exception;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Runs tests on the `Phine\Exception\Exception` class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class ExceptionTest extends TestCase
+{
+    /**
+     * Creates a new exception using a couple of values for formatting without
+     * passing a `$previous` exception. The exception returned should have the
+     * properly formatted message, and without a previous exception set.
+     */
+    public function testCreateUsingFormat()
+    {
+        $exception = Exception::createUsingFormat(
+            'This is %s %drd message.',
+            'my',
+            3
+        );
+
+        $this->assertInstanceOf(
+            'Phine\\Exception\\Exception',
+            $exception
+        );
+
+        $this->assertEquals(
+            'This is my 3rd message.',
+            $exception->getMessage()
+        );
+
+        $this->assertNull($exception->getPrevious());
+    }
+
+    /**
+     * Nearly identical to the `testCreateUsingFormat()` test, but this time
+     * a `$previous` exception will be passed. The message should be the same
+     * as before, but the `$previous` exception must be returned this time.
+     */
+    public function testCreateUsingFormatWithPrevious()
+    {
+        $previous = new \Exception('The previous exception.');
+        $exception = Exception::createUsingFormat(
+            'This is %s %drd message.',
+            'my',
+            3,
+            $previous
+        );
+
+        $this->assertInstanceOf(
+            'Phine\\Exception\\Exception',
+            $exception
+        );
+
+        $this->assertEquals(
+            'This is my 3rd message.',
+            $exception->getMessage()
+        );
+
+        $this->assertSame(
+            $previous,
+            $exception->getPrevious()
+        );
+    }
+
+    /**
+     * **No errors should be generated prior to this test.** This test will
+     * check that the default message "(unknown error)" is used if no error
+     * has been generated.
+     */
+    public function testCreateUsingLastErrorWithDefault()
+    {
+        $exception = Exception::createUsingLastError();
+
+        $this->assertInstanceOf(
+            'Phine\\Exception\\Exception',
+            $exception
+        );
+
+        $this->assertEquals(
+            '(unknown error)',
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * Like the `testCreateUsingLastErrorWithDefault()` test, no errors should
+     * be generated prior to this test. This test will check that the user given
+     * default message is used if no error has been generated.
+     */
+    public function testCreateUsingLastErrorWithDefaultGiven()
+    {
+        $default = 'The default message.';
+        $exception = Exception::createUsingLastError(null, $default);
+
+        $this->assertInstanceOf(
+            'Phine\\Exception\\Exception',
+            $exception
+        );
+
+        $this->assertEquals(
+            $default,
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * Generates a warning by accessing an undefined variable. An exception
+     * will then be created using the default arguments. The message will
+     * then be directly compared to the one returned by `error_get_last()`,
+     * since they should be identical.
+     */
+    public function testCreateUsingLastError()
+    {
+        @$undefinedCreateUsingLastError;
+
+        $exception = Exception::createUsingLastError();
+
+        $this->assertInstanceOf(
+            'Phine\\Exception\\Exception',
+            $exception
+        );
+
+        $error = error_get_last();
+
+        $this->assertEquals(
+            $error['message'],
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * Almost identical to the `testCreateUsingLastError()` test, but a prefix
+     * is defined this time. Like the previous test, the message should be the
+     * same, but the prefix added.
+     *
+     * @depends testCreateUsingLastError
+     */
+    public function testCreateUsingLastErrorWithPrefix()
+    {
+        @$undefinedCreateUsingLastErrorWithPrefix;
+
+        $prefix = 'This is the prefix: ';
+        $exception = Exception::createUsingLastError($prefix);
+
+        $this->assertInstanceOf(
+            'Phine\\Exception\\Exception',
+            $exception
+        );
+
+        $error = error_get_last();
+
+        $this->assertEquals(
+            $prefix . $error['message'],
+            $exception->getMessage()
+        );
+    }
+}

--- a/lib/phine/observer/.gitignore
+++ b/lib/phine/observer/.gitignore
@@ -1,0 +1,7 @@
+/.idea/
+/coverage/
+/src/vendors/
+
+/*.iml
+/composer.lock
+/coverage.xml

--- a/lib/phine/observer/.travis-phpunit.xml
+++ b/lib/phine/observer/.travis-phpunit.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="src/tests/bootstrap.php" colors="true" strict="true">
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src/lib/</directory>
+    </whitelist>
+  </filter>
+  <logging>
+    <log type="coverage-clover" target="/tmp/coverage.xml"/>
+    <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+  </logging>
+  <listeners>
+    <listener class="League\PHPUnitCoverageListener\Listener">
+      <arguments>
+        <array>
+          <element key="namespace">
+            <string>Phine\Observer</string>
+          </element>
+          <element key="repo_token">
+            <string>QVnUd8GLjBQpc6bCOCTpawl02GHJBDfFN</string>
+          </element>
+          <element key="target_url">
+            <string>https://coveralls.io/api/v1/jobs</string>
+          </element>
+          <element key="printer">
+            <object class="League\PHPUnitCoverageListener\Printer\StdOut"/>
+          </element>
+          <element key="hook">
+            <object class="League\PHPUnitCoverageListener\Hook\Travis"/>
+          </element>
+          <element key="coverage_dir">
+            <string>/tmp</string>
+          </element>
+        </array>
+      </arguments>
+    </listener>
+  </listeners>
+  <testsuites>
+    <testsuite name="Phine Observer Test Suite">
+      <directory phpVersion="5.3.3" phpVersionOperator=">=" suffix="Test.php">src/tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/lib/phine/observer/.travis.yml
+++ b/lib/phine/observer/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+    - 5.3
+    - 5.4
+    - 5.5
+
+before_script:
+    - composer self-update
+    - composer install --dev --no-interaction --prefer-source
+
+script: phpunit -c .travis-phpunit.xml

--- a/lib/phine/observer/CONTRIBUTING.md
+++ b/lib/phine/observer/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+Contributing
+============
+
+To contribute, please follow the [PSR-2][] guidelines.
+
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md

--- a/lib/phine/observer/LICENSE
+++ b/lib/phine/observer/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2013 Kevin Herrera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/phine/observer/README.md
+++ b/lib/phine/observer/README.md
@@ -1,0 +1,260 @@
+Observer
+========
+
+[![Build Status][]](https://travis-ci.org/phine/lib-observer)
+[![Coverage Status][]](https://coveralls.io/r/phine/lib-observer)
+[![Latest Stable Version][]](https://packagist.org/packages/phine/observer)
+[![Total Downloads][]](https://packagist.org/packages/phine/observer)
+
+A PHP library that implements the observer pattern.
+
+Summary
+-------
+
+This library provides an implementation of the [observer pattern][]. You can
+use it to create other libraries such as event managers, state machines, MVC
+frameworks, and even provide a plugin system for application.
+
+Requirement
+-----------
+
+- PHP >= 5.3.3
+- [Phine Exception][] >= 1.0.0
+
+Installation
+------------
+
+Via [Composer][]:
+
+    $ composer require "phine/observer=~2.0"
+
+Usage
+-----
+
+To create a subject, you will need to either create your own implementation
+of `SubjectInterface`, or use the bundled `Subject` class.
+
+```php
+use Phine\Observer\Subject;
+
+$subject = new Subject();
+```
+
+### Observing
+
+You will then need to create your own implementation of `ObserverInterface`
+to observe changes made to the subject. You may use multiple instances of
+the observer implementation, or even the same instance multiple times.
+
+```php
+use Phine\Observer\ObserverInterface;
+use Phine\Observer\SubjectInterface;
+
+// register a few instances
+$subject->registerObserver(new Message('First'));
+$subject->registerObserver(new Message('Second'));
+
+// register the same one twice
+$reuse = new Message('Third');
+
+$subject->registerObserver($reuse);
+$subject->registerObserver($reuse);
+
+// notify all observers of an update
+$subject->notifyObservers();
+
+/**
+ * Simply echos a message when updated.
+ */
+class Message implements ObserverInterface
+{
+    /**
+     * The message to echo.
+     *
+     * @var string
+     */
+    private $message;
+
+    /**
+     * Sets the message to echo on update.
+     *
+     * @param string $message The message.
+     */
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function receiveUpdate(SubjectInterface $subject)
+    {
+        echo $this->message, "\n";
+    }
+}
+```
+
+With the example above, you can expect the following output:
+
+    First
+    Second
+    Third
+    Third
+
+### Prioritizing Observers
+
+Implementations of `SubjectInterface` support prioritizing observers during
+registration (`registerObserver()`). By default, shown in all the examples
+provided, the priority is `SubjectInterface::FIRST_PRIORITY` (which is `0`,
+zero). You may, however, specify your own priority:
+
+```php
+$subject->registerObserver(new Message('A'), SubjectInterface::LAST_PRIORITY);
+$subject->registerObserver(new Message('B'), 789);
+$subject->registerObserver(new Message('C'), 123);
+$subject->registerObserver(new Message('D'), 456);
+$subject->registerObserver(new Message('E'), SubjectInterface::FIRST_PRIORITY);
+```
+
+With the above example, you can expect the following output:
+
+    E
+    C
+    D
+    B
+    A
+
+When a subject updates its observers it begins at priority `0` (zero), and works
+its way to `PHP_INT_MAX` (the lowest possible priority). If multiple observers
+are registered using the same provider, they will be updated in the order that
+they were registered.
+
+### Interrupting an Update
+
+When a subject is in the process of updating its registered observers, an
+observer may interrupt the subject. An interrupt is performed by an observer
+when it calls the `SubjectInterface::interruptUpdate()` method.
+
+```php
+use Phine\Observer\Exception\ReasonException;
+
+/**
+ * Simply interrupts the subject in the middle of an update.
+ */
+class InterruptingCow implements ObserverInterface
+{
+    /**
+     * Interrupts the update.
+     */
+    public function receiveUpdate(SubjectInterface $subject)
+    {
+        // do some work
+
+        $subject->interruptUpdate(
+            new ReasonException('MOOOOO')
+        );
+
+        // do some final work
+    }
+}
+```
+
+Using the following example:
+
+```php
+// create a new subject
+$subject = new Subject();
+
+// register some observers
+$subject->registerObserver(new Message('So what did the interrupt cow say?'));
+$subject->registerObserver(new InterruptingCow());
+$subject->registerObserver(new Message('We never get this far.'));
+
+// notify the observers
+$subject->notifyObservers();
+```
+
+You can expect the following output:
+
+    So what did the interrupting cow say?
+    PHP Fatal error:  Uncaught exception '[...]' with message 'MOOOOO' [...]
+    [...]
+
+Observers are not required to provide a reason (instance of `ReasonException`),
+but it will definitely help during the debugging process if one is given.
+
+### Collections of Subjects
+
+There may be occasions where you will need to manage a collection of subjects.
+The library provides two ways of doing so: `Collection` and `ArrayCollection`.
+The `Collection` will associate an individual subject with a specific unique
+identifier.
+
+```php
+use Phine\Observer\Collection;
+
+// create a new collection
+$collection = new Collection();
+
+// register a few subjects
+$collection->registerSubject('one', new Subject());
+$collection->registerSubject('two', new Subject());
+$collection->registerSubject('three', new Subject());
+```
+
+You can then retrieve the subjects or replace them as needed.
+
+```php
+// replace one
+$collection->registerSubject('two', new Subject());
+
+// update observers of another
+$collection->getSubject('three')->notifyObservers();
+```
+
+The `ArrayCollection` class provides a leaner way of managing subject
+registrations. It is an extension of the `Collection` class that supports
+array access through `ArrayCollectionInterface`.
+
+```php
+use Phine\Observer\ArrayCollection;
+
+// create a new collection
+$collection = new ArrayCollection();
+
+// register a few subjects
+$collection['one'] = new Subject();
+$collection['two'] = new Subject();
+$collection['three'] = new Subject();
+```
+
+Like the regular `Collection` class, you can also replace and retrieve
+individual subjects.
+
+```php
+// replace one
+$collection['two'] = new Subject();
+
+// update observers of another
+$collection['three']->notifyObservers();
+```
+
+Documentation
+-------------
+
+You can find the [API documentation here][].
+
+License
+-------
+
+This library is available under the [MIT license](LICENSE).
+
+[Build Status]: https://travis-ci.org/phine/lib-observer.png?branch=master
+[Coverage Status]: https://coveralls.io/repos/phine/lib-observer/badge.png
+[Latest Stable Version]: https://poser.pugx.org/phine/observer/v/stable.png
+[Total Downloads]: https://poser.pugx.org/phine/observer/downloads.png
+[observer pattern]: http://en.wikipedia.org/wiki/Observer_pattern
+[Phine Exception]: https://github.com/phine/lib-exception
+[Composer]: http://getcomposer.org/
+[API documentation here]: http://phine.github.io/lib-observer

--- a/lib/phine/observer/composer.json
+++ b/lib/phine/observer/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "phine/observer",
+    "description": "A PHP library that implements the observer pattern.",
+    "keywords": ["observer"],
+    "homepage": "https://github.com/phine/lib-observer",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Kevin Herrera",
+            "email": "kevin@herrera.io",
+            "homepage": "http://kevin.herrera.io"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/phine/lib-observer/issues"
+    },
+    "require": {
+        "php": ">=5.3.3",
+        "phine/exception": "~1.0"
+    },
+    "require-dev": {
+        "league/phpunit-coverage-listener": "~1.0",
+        "phine/test": "~1.0"
+    },
+    "autoload": {
+        "psr-0": {
+            "Phine\\Observer": "src/lib"
+        }
+    },
+    "config": {
+        "bin-dir": "bin",
+        "vendor-dir": "src/vendors"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    }
+}

--- a/lib/phine/observer/phpunit.xml.dist
+++ b/lib/phine/observer/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="src/tests/bootstrap.php" colors="true" strict="true">
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src/lib/</directory>
+    </whitelist>
+  </filter>
+  <logging>
+    <log type="coverage-clover" target="coverage.xml"/>
+  </logging>
+  <testsuites>
+    <testsuite name="Phine Observer Test Suite">
+      <directory phpVersion="5.3.3" phpVersionOperator=">=" suffix="Test.php">src/tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/lib/phine/observer/src/lib/Phine/Observer/ArrayCollection.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/ArrayCollection.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Phine\Observer;
+
+/**
+ * The default implementation of `ArrayCollectionInterface`.
+ *
+ * Summary
+ * -------
+ *
+ * The `ArrayCollection` class is an implementation of `ArrayCollectionInterface`.
+ * You may use the implementation as an authoritative example of how the interface
+ * should be implemented. You may optionally extend the class to add (not modify)
+ * new functionality that you may need.
+ *
+ * Starting
+ * --------
+ *
+ * To start, you will need to simply create an instance of `ArrayCollection`:
+ *
+ *     $collection = new ArrayCollection();
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class ArrayCollection extends Collection implements ArrayCollectionInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($id)
+    {
+        return $this->isSubjectRegistered($id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetGet($id)
+    {
+        return $this->getSubject($id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($id, $subject)
+    {
+        if ($this->isSubjectRegistered($id)) {
+            $this->replaceSubject($id, $subject);
+        } else {
+            $this->registerSubject($id, $subject);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($id)
+    {
+        if ($this->isSubjectRegistered($id)) {
+            $this->unregisterSubject($id);
+        }
+    }
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/ArrayCollectionInterface.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/ArrayCollectionInterface.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Phine\Observer;
+
+use ArrayAccess;
+use Phine\Observer\Exception\CollectionException;
+
+/**
+ * Defines how an array accessible subject collection class must be implemented.
+ *
+ * Summary
+ * -------
+ *
+ * The `ArrayCollectionInterface` is an extension of `CollectionInterface`
+ * that allows for array access. Using array access provides the ability
+ * to reduce the amount of boilerplate code that is used to manage subjects
+ * and their observers, adding convenience.
+ *
+ * Starting
+ * --------
+ *
+ * To create a new array accessible collection, you will need to create an
+ * implementation of `ArrayCollectionInterface`. In this example, I will be
+ * using the bundled `ArrayCollection` class.
+ *
+ *     use Phine\Observer\ArrayCollection;
+ *
+ *     $collection = new ArrayCollection();
+ *
+ * ### Managing Subjects
+ *
+ * Managing subject registrations with an array accessible collection is as
+ * simple as... accessing an array! You can perform all collection actions
+ * via array access. It is important to note that exceptions will still be
+ * thrown for some conditions, such as accessing unregistered unique
+ * identifiers.
+ *
+ *     // register new subjects
+ *     $collection['one'] = new Subject();
+ *     $collection['two'] = new Subject();
+ *     $collection['three'] = new Subject();
+ *
+ *     // replace an existing one
+ *     $collection['two'] = new Subject();
+ *
+ *     // unregister an existing one
+ *     unset($collection['one']);
+ *
+ *     // use an existing one
+ *     $collection['three']->notifyObservers();
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ *
+ * @api
+ */
+interface ArrayCollectionInterface extends ArrayAccess, CollectionInterface
+{
+    /**
+     * Checks if a subject is registered with this collection.
+     *
+     * This method will check if a subject was registered using the specified
+     * unique identifier. If an identifier is registered currently registered,
+     * `true` is returned.
+     *
+     *     if (isset($collection['my_id'])) {
+     *         // registered
+     *     }
+     *
+     * @param string $id The unique identifier of the subject.
+     *
+     * @return boolean Returns `true` if a subject with the given unique
+     *                 identifier is registered with this collection. If
+     *                 a subject is not found, `false` is returned.
+     *
+     * @api
+     */
+    public function offsetExists($id);
+
+    /**
+     * Returns the subject with the unique identifier.
+     *
+     * This method will return the subject that was registered with the
+     * specified unique identifier. If a subject was not registered with
+     * the unique identifier, an exception is thrown.
+     *
+     *     $subject = $collection['my_id'];
+     *
+     * @param string $id The unique identifier.
+     *
+     * @return SubjectInterface The registered subject.
+     *
+     * @throws CollectionException If the unique identifier is not used.
+     *
+     * @api
+     */
+    public function offsetGet($id);
+
+    /**
+     * Registers or replaces a subject with the unique identifier.
+     *
+     * This method will register the given identifier with the specified
+     * unique identifier in this collection. If the unique identifier has
+     * already been used, the registered subject will be replaced with the
+     * new one provided.
+     *
+     *     // new
+     *     $collection['my_id'] = new Subject();
+     *
+     *     // replace
+     *     $collection['my_id'] = new Subject();
+     *
+     * @param string           $id      The unique identifier.
+     * @param SubjectInterface $subject The subject to register.
+     *
+     * @api
+     */
+    public function offsetSet($id, $subject);
+
+    /**
+     * Unregisters a subject from the collection.
+     *
+     * This method will unregister a subject that was registered with the
+     * specified unique identifier.
+     *
+     *     unset($collection['my_id']);
+     *
+     * @param string $id The unique identifier.
+     *
+     * @api
+     */
+    public function offsetUnset($id);
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/Collection.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/Collection.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Phine\Observer;
+
+use Phine\Observer\Exception\CollectionException;
+
+/**
+ * The default implementation of `CollectionInterface`.
+ *
+ * Summary
+ * -------
+ *
+ * The `Collection` class is an implementation of `CollectionInterface`. You
+ * may use the implementation as an authoritative example of how the interface
+ * should be implemented. You may optionally extend the class to add (not
+ * modify) new functionality that you may need.
+ *
+ * Starting
+ * --------
+ *
+ * To start, you will need to simply create an instance of `Collection`:
+ *
+ *     $collection = new Collection();
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ *
+ * @api
+ */
+class Collection implements CollectionInterface
+{
+    /**
+     * The registered subjects.
+     *
+     * @var SubjectInterface[]
+     */
+    private $subjects = array();
+
+    /**
+     * {@inheritDoc}
+     */
+    public function copySubjects(CollectionInterface $collection)
+    {
+        $this->subjects = array_merge(
+            $this->subjects,
+            $collection->getSubjects()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSubject($id)
+    {
+        if (!isset($this->subjects[$id])) {
+            throw CollectionException::idNotUsed($id);
+        }
+
+        return $this->subjects[$id];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSubjects()
+    {
+        return $this->subjects;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSubjectRegistered($id)
+    {
+        return isset($this->subjects[$id]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function registerSubject($id, SubjectInterface $subject)
+    {
+        if (isset($this->subjects[$id])) {
+            throw CollectionException::idUsed($id);
+        }
+
+        $this->subjects[$id] = $subject;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function replaceSubject($id, SubjectInterface $subject)
+    {
+        if (!isset($this->subjects[$id])) {
+            throw CollectionException::idNotUsed($id);
+        }
+
+        $this->subjects[$id] = $subject;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function replaceSubjects(CollectionInterface $collection)
+    {
+        $this->subjects = $collection->getSubjects();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unregisterSubject($id)
+    {
+        if (!isset($this->subjects[$id])) {
+            throw CollectionException::idNotUsed($id);
+        }
+
+        unset($this->subjects[$id]);
+    }
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/CollectionInterface.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/CollectionInterface.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Phine\Observer;
+
+use Phine\Observer\Exception\CollectionException;
+
+/**
+ * Defines how a subject collection class must be implemented.
+ *
+ * Summary
+ * -------
+ *
+ * A class implementing `CollectionInterface` will associate each subject that
+ * is registered with it a unique identifier. This unique identifier can then
+ * be used as a way to manage subjects without directly knowing which instance
+ * should be used.
+ *
+ * Starting
+ * --------
+ *
+ * To create a new collection, you will need to create an implementation of
+ * `CollectionInterface`. In this example, I will be using the `Collection`,
+ * a bundled implementation of the interface.
+ *
+ *     use Phine\Observers\Collection;
+ *
+ *     $collection = new Collection();
+ *
+ * ### Managing Subjects
+ *
+ * Once you have created your collection, you will want to register one or
+ * more subjects. Subjects are registered by association a specific unique
+ * identifier for each subject in the collection. You may register the same
+ * subject with different identifiers, but you may not register multiple
+ * subjects to the same identifier.
+ *
+ *     use Phine\Observers\Subject;
+ *
+ *     // create our subjects
+ *     $subject1 = new Subject();
+ *     $subject2 = new Subject();
+ *     $subject3 = new Subject();
+ *
+ *     // register them with unique identifiers
+ *     $collection->registerSubject('one', $subject1);
+ *     $collection->registerSubject('two', $subject2);
+ *     $collection->registerSubject('three', $subject3);
+ *     $collection->registerSubject('four', $subject3);
+ *
+ *     // this attempt will thrown an exception
+ *     $collection->registerSubject('three', $subject1);
+ *
+ * ### Replacing Subjects
+ *
+ * At some point, you may have a process that will swap one subject for
+ * another. The collection will not allow multiple registrations for a
+ * single unique identifier, but it will allow you to replace existing
+ * subjects with other ones.
+ *
+ *     $subject4 = new Subject();
+ *
+ *     $collection->replaceSubject('four', $subject4);
+ *
+ * If you attempt to replace a subject for a unique identifier that has not
+ * been used, an exception will be thrown. To prevent this from happening,
+ * you will want to check the registration of a unique identifier first.
+ *
+ *     $subject5 = new Subject();
+ *
+ *     if ($collection->isSubjectRegistered('five')) {
+ *         $collection->replaceSubject('five', $subject5);
+ *     } else {
+ *          $collection->registerSubject('five', $subject5);
+ *     }
+ *
+ * ### Accessing Subjects
+ *
+ * After your subjects have been registered or replaced, you will want to
+ * eventually use them.
+ *
+ *     $subject = $collection->getSubject('one');
+ *     $subject->notifyObservers();
+ *
+ *     // alternatively
+ *
+ *     $collection->getSubject('one')->notifyObservers();
+ *
+ * ### Unregistering Subjects
+ *
+ * Unregistering a subject is as simple as registering one. However, if you
+ * attempt to unregister a subject with a unique identifier that has not been
+ * used, an exception is thrown. You will want to check for registration before
+ * actually unregistering the subject.
+ *
+ *     if ($collection->isSubjectRegistered('three')) {
+ *         $collection->unregisterSubject('three');
+ *     }
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ *
+ * @api
+ */
+interface CollectionInterface
+{
+    /**
+     * Copies subjects from another collection.
+     *
+     * This method will register the subjects of another collection with this
+     * collection. If the given collection has one or more subjects with the
+     * same unique identifier as those already registered with this collection,
+     * the subjects will be replaced with the ones being copied.
+     *
+     *     $collection->copySubjects($anotherCollection);
+     *
+     * @param CollectionInterface $collection A collection to copy from.
+     *
+     * @api
+     */
+    public function copySubjects(CollectionInterface $collection);
+
+    /**
+     * Returns the subject with the unique identifier.
+     *
+     * This method will return the subject that was registered with the
+     * specified unique identifier. If a subject was not registered with
+     * the unique identifier, an exception is thrown.
+     *
+     *     $subject = $collection->getSubject('my_id');
+     *
+     * @param string $id The unique identifier.
+     *
+     * @return SubjectInterface The registered subject.
+     *
+     * @throws CollectionException If the unique identifier is not used.
+     *
+     * @api
+     */
+    public function getSubject($id);
+
+    /**
+     * Returns a list of subjects registered to this collection.
+     *
+     * This method will return a list of subjects that have been registered
+     * with this collection. The list is return is an array with the key being
+     * the unique identifier of the subject (which is the value).
+     *
+     *     $subjects = $collection->getSubjects();
+     *
+     * @return SubjectInterface[] The list of subjects.
+     *
+     * @api
+     */
+    public function getSubjects();
+
+    /**
+     * Checks if a subject is registered with this collection.
+     *
+     * This method will check if a subject was registered using the specified
+     * unique identifier. If an identifier is registered currently registered,
+     * `true` is returned.
+     *
+     *     if ($collection->isSubjectRegistered('my_id')) {
+     *         // registered
+     *     }
+     *
+     * @param string $id The unique identifier of the subject.
+     *
+     * @return boolean Returns `true` if a subject with the given unique
+     *                 identifier is registered with this collection. If
+     *                 a subject is not found, `false` is returned.
+     *
+     * @api
+     */
+    public function isSubjectRegistered($id);
+
+    /**
+     * Registers a subject with a unique identifier in this collection.
+     *
+     * This method will register the given identifier with the specified
+     * unique identifier in this collection. If the unique identifier has
+     * already been used, an exception is thrown.
+     *
+     *     $collection->registerSubject('my_id', $subject);
+     *
+     * @param string           $id      The unique identifier.
+     * @param SubjectInterface $subject The subject to register.
+     *
+     * @throws CollectionException If the unique identifier is already used.
+     *
+     * @api
+     */
+    public function registerSubject($id, SubjectInterface $subject);
+
+    /**
+     * Replaces a subject registered with a unique identifier.
+     *
+     * This method will replace a subject that has been registered with the
+     * specified unique identifier with the given subject. If a subject has
+     * not already been registered with the unique identifier, an exception
+     * is thrown.
+     *
+     *     $subject->replaceSubject('my_id', $anotherSubject);
+     *
+     * @param string           $id      The unique identifier.
+     * @param SubjectInterface $subject The new subject.
+     *
+     * @throws CollectionException If the unique identifier is not used.
+     *
+     * @api
+     */
+    public function replaceSubject($id, SubjectInterface $subject);
+
+    /**
+     * Replaces the subjects for this collection using subjects from another.
+     *
+     * This method will replace the subjects of this collection with the
+     * subjects registered with the given collection. Any previous subjects
+     * registered with this collection will be forgotten.
+     *
+     *     $subject->replaceSubjects($anotherCollection);
+     *
+     * @param CollectionInterface $collection A collection to replace with.
+     *
+     * @api
+     */
+    public function replaceSubjects(CollectionInterface $collection);
+
+    /**
+     * Unregisters a subject from the collection.
+     *
+     * This method will unregister a subject that was registered with the
+     * specified unique identifier. If a subject has not been registered
+     * with the unique identifier, an exception is thrown.
+     *
+     *     $subject->unregisterSubject('my_id');
+     *
+     * @param string $id The unique identifier.
+     *
+     * @throws CollectionException If the unique identifier is not used.
+     *
+     * @api
+     */
+    public function unregisterSubject($id);
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/Exception/CollectionException.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/Exception/CollectionException.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phine\Observer\Exception;
+
+use Phine\Exception\Exception;
+
+/**
+ * Exception thrown when a problem with the collection is encountered.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class CollectionException extends Exception
+{
+    /**
+     * Creates a new exception for a unique identifier that is not used.
+     *
+     * @param string $id The unique identifier.
+     *
+     * @return CollectionException The new exception.
+     */
+    public static function idNotUsed($id)
+    {
+        return self::createUsingFormat(
+            'The "%s" subject unique identifier is not in use.',
+            $id
+        );
+    }
+
+    /**
+     * Creates a new exception for a unique identifier that is already used.
+     *
+     * @param string $id The unique identifier.
+     *
+     * @return CollectionException The new exception.
+     */
+    public static function idUsed($id)
+    {
+        return self::createUsingFormat(
+            'The "%s" subject unique identifier is already in use.',
+            $id
+        );
+    }
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/Exception/ReasonException.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/Exception/ReasonException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phine\Observer\Exception;
+
+use Phine\Exception\Exception;
+
+/**
+ * A throwable reason for interrupting an observer update.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class ReasonException extends Exception
+{
+    /**
+     * Creates an exception for when a reason is not provided.
+     *
+     * @return ReasonException The new exception.
+     */
+    public static function notSpecified()
+    {
+        return new self('(no reason specified)');
+    }
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/Exception/SubjectException.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/Exception/SubjectException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Phine\Observer\Exception;
+
+use Phine\Exception\Exception;
+
+/**
+ * Exception thrown when a problem with the subject is encountered.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class SubjectException extends Exception
+{
+    /**
+     * Creates a new exception for when a subject is already updating.
+     *
+     * @return SubjectException The new exception.
+     */
+    public static function alreadyUpdating()
+    {
+        return new self(
+            'There is already an update in progress.'
+        );
+    }
+
+    /**
+     * Creates a new exception for when an interrupt is made without an update.
+     *
+     * @return SubjectException The new exception.
+     */
+    public static function notUpdating()
+    {
+        return new self(
+            'There is no update in progress to interrupt.'
+        );
+    }
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/ObserverInterface.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/ObserverInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phine\Observer;
+
+/**
+ * Defines how an observer class must be implemented.
+ *
+ * Summary
+ * -------
+ *
+ * A class implementing `ObserverInterface` will be able to receive updates
+ * from any subject that implements `SubjectInterface`.
+ *
+ * Starting
+ * --------
+ *
+ * To create a new observer, you will need to create an implementation of
+ * `ObserverInterface`.
+ *
+ *     use Phine\Observer\ObserverInterface;
+ *     use Phine\Observer\SubjectInterface;
+ *
+ *     class MyObserver implements ObserverInterface
+ *     {
+ *         public function receiveUpdate(SubjectInterface $subject)
+ *         {
+ *             // do stuff
+ *         }
+ *     }
+ *
+ * ### Interrupting the Update
+ *
+ * If the observer receives an update, it can interrupt the subject and prevent
+ * it from updating the remaining observers. This can be accomplished by using
+ * the `$subject->interruptUpdate()` method.
+ *
+ * @see SubjectInterface::interruptUpdate()
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ *
+ * @api
+ */
+interface ObserverInterface
+{
+    /**
+     * Receives an update from an observed subject.
+     *
+     * @param SubjectInterface $subject The subject being observed.
+     *
+     * @api
+     */
+    public function receiveUpdate(SubjectInterface $subject);
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/Subject.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/Subject.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Phine\Observer;
+
+use Exception;
+use Phine\Observer\Exception\ReasonException;
+use Phine\Observer\Exception\SubjectException;
+
+/**
+ * The default implementation of `SubjectInterface`.
+ *
+ * Summary
+ * -------
+ *
+ * The `Subject` class is an implementation of `SubjectInterface`. You may use
+ * the implementation as an authoritative example of how the interface should
+ * be implemented. You may optionally extend the class to add (not modify) new
+ * functionality that you may need.
+ *
+ * Starting
+ * --------
+ *
+ * To start, you will need to simply create an instance of `Subject`:
+ *
+ *     use Phine\Observer\Subject;
+ *
+ *     $subject = new Subject();
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ *
+ * @api
+ */
+class Subject implements SubjectInterface
+{
+    /**
+     * The registered observers.
+     *
+     * @var array
+     */
+    private $observers = array();
+
+    /**
+     * The reason for the last interrupt.
+     *
+     * @var ReasonException
+     */
+    private $reason;
+
+    /**
+     * The flag used to determine if an update is in progress.
+     *
+     * @var boolean
+     */
+    private $updating = false;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function copyObservers(SubjectInterface $subject)
+    {
+        foreach ($subject->getObservers() as $priority => $observers) {
+            if (isset($this->observers[$priority])) {
+                $this->observers[$priority] = array_merge(
+                    $this->observers[$priority],
+                    $observers
+                );
+            } else {
+                $this->observers[$priority] = $observers;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInterruptReason()
+    {
+        return $this->reason;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getObservers()
+    {
+        ksort($this->observers, SORT_NUMERIC);
+
+        return $this->observers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasObserver(ObserverInterface $observer, $priority = null)
+    {
+        if (null === $priority) {
+            foreach ($this->observers as $observers) {
+                if (in_array($observer, $observers, true)) {
+                    return true;
+                }
+            }
+        } elseif (isset($this->observers[$priority])) {
+            return in_array($observer, $this->observers[$priority], true);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDocs}
+     */
+    public function hasObservers($priority = null)
+    {
+        if (null === $priority) {
+            foreach ($this->observers as $observers) {
+                if (!empty($observers)) {
+                    return true;
+                }
+            }
+        } elseif (isset($this->observers[$priority])) {
+            return !empty($this->observers[$priority]);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function interruptUpdate(ReasonException $reason = null)
+    {
+        if (false === $this->updating) {
+            throw SubjectException::notUpdating();
+        }
+
+        if (null === $reason) {
+            $reason = ReasonException::notSpecified();
+        }
+
+        $this->reason = $reason;
+        $this->updating = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInterrupted()
+    {
+        return (null !== $this->reason);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isUpdating()
+    {
+        return $this->updating;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function notifyObservers()
+    {
+        if ($this->updating) {
+            throw SubjectException::alreadyUpdating();
+        }
+
+        $this->resetInterrupt();
+
+        $this->updating = true;
+
+        /** @var ObserverInterface $observer */
+        foreach ($this->getObservers() as $observers) {
+            foreach ($observers as $observer) {
+                try {
+                $observer->receiveUpdate($this);
+                } catch (Exception $exception) {
+                    $this->updating = false;
+
+                    throw $exception;
+                }
+
+                if ($this->reason) {
+                    $this->updating = false;
+
+                    throw $this->reason;
+                }
+            }
+        }
+
+        $this->updating = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function registerObserver(
+        ObserverInterface $observer,
+        $priority = self::FIRST_PRIORITY
+    ) {
+        if (!isset($this->observers[$priority])) {
+            $this->observers[$priority] = array();
+        }
+
+        $this->observers[$priority][] = $observer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function replaceObservers(SubjectInterface $subject)
+    {
+        $this->observers = $subject->getObservers();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unregisterAllObservers(
+        ObserverInterface $observer = null,
+        $priority = null
+    ) {
+        if ($observer) {
+            if (null === $priority) {
+                foreach ($this->observers as $priority => $observers) {
+                    foreach (array_keys($observers, $observer, true) as $key) {
+                        unset($this->observers[$priority][$key]);
+                    }
+                }
+            } elseif (isset($this->observers[$priority])) {
+                foreach (array_keys($this->observers[$priority], $observer, true) as $key) {
+                    unset($this->observers[$priority][$key]);
+                }
+            }
+        } elseif (null === $priority) {
+            $this->observers = array();
+        } else {
+            unset($this->observers[$priority]);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unregisterObserver(
+        ObserverInterface $observer,
+        $priority = null
+    ) {
+        if (null === $priority) {
+            foreach ($this->getObservers() as $priority => $observers) {
+                if (false !== ($key = array_search($observer, $observers, true))) {
+                    unset($this->observers[$priority][$key]);
+
+                    break;
+                }
+            }
+        } elseif (isset($this->observers[$priority])) {
+            if (false !== ($key = array_search($observer, $this->observers[$priority], true))) {
+                unset($this->observers[$priority][$key]);
+            }
+        }
+    }
+
+    /**
+     * Resets any interruption made by the last update.
+     */
+    protected function resetInterrupt()
+    {
+        $this->reason = null;
+    }
+}

--- a/lib/phine/observer/src/lib/Phine/Observer/SubjectInterface.php
+++ b/lib/phine/observer/src/lib/Phine/Observer/SubjectInterface.php
@@ -1,0 +1,506 @@
+<?php
+
+namespace Phine\Observer;
+
+use Phine\Observer\Exception\ReasonException;
+use Phine\Observer\Exception\SubjectException;
+
+/**
+ * Defines how a subject class must be implemented.
+ *
+ * Summary
+ * -------
+ *
+ * A class implementing `SubjectInterface` will be the subject in the observer
+ * pattern. In addition to simply being capable of having observers registered,
+ * a priority can be set for each observer.
+ *
+ * Starting
+ * --------
+ *
+ * To create a new subject, you will need to create an implementation of
+ * `SubjectInterface`. In this example, I will be using the bundled `Subject`
+ * implementation.
+ *
+ *     use Phine\Observer\Subject;
+ *
+ *     $subject = new Subject();
+ *
+ * Observing
+ * ---------
+ *
+ * To observer the subject for changes, you will first need an implementation
+ * of `ObserverInterface`. The implementation will be responsible for receiving
+ * updates from any subject it is registered to.
+ *
+ *     use Phine\Observer\ObserverInterface;
+ *     use Phine\Observer\SubjectInterface;
+ *
+ *     class MyObserver implements ObserverInterface
+ *     {
+ *         private $name;
+ *
+ *         public function __construct($name)
+ *         {
+ *             $this->name = $name;
+ *         }
+ *
+ *         public function receiveUpdate(SubjectInterface $subject)
+ *         {
+ *             echo 'Updated: ', $this->name, "\n";
+ *         }
+ *     }
+ *
+ * Once you have your implementation, you will need to register it.
+ *
+ *     $observer = new MyObserver('example');
+ *
+ *     $subject->registerObserver($observer);
+ *
+ * What is not shown in the example is that the observer has been registered
+ * with the priority of `SubjectInterface::FIRST_PRIORITY` (`0`, zero). This
+ * means that the observer will receive an update before any observer with a
+ * priority number higher than `0` (zero). You may specify the registration
+ * priority number as a second argument.
+ *
+ *     $subject->registerObserver($observer, 123);
+ *
+ * The highest priority number is `SubjectInterface::LAST_PRIORITY`, which is
+ * an alias for `PHP_INT_MAX`. If multiple observers have been registered with
+ * the same priority number, the observers will be updated in the order they
+ * have been registered.
+ *
+ * > It might be useful to know that a single observer instance may be
+ * > registered multiple times, in the same or different priority.
+ *
+ * Updating
+ * --------
+ *
+ * When a change is made to the subject, the observers should be updated.
+ *
+ *     $subject->notifyObservers();
+ *
+ * The observers will be updated in priority and registration order. Assume
+ * we registered the following observers using the example implementation that
+ * was shown earlier:
+ *
+ *     $subject->registerObserver(new MyObserver('A'), 10);
+ *     $subject->registerObserver(new MyObserver('B'));
+ *     $subject->registerObserver(new MyObserver('C'), Subject::LAST_PRIORITY);
+ *     $subject->registerObserver(new MyObserver('D'));
+ *     $subject->registerObserver(new MyObserver('E'), 20);
+ *
+ * If we notify the observers of an update:
+ *
+ *     $subject->notifyObservers();
+ *
+ * The output from the observers will be:
+ *
+ *     Updated: B
+ *     Updated: D
+ *     Updated: A
+ *     Updated: E
+ *     Updated: C
+ *
+ * ### Interrupting an Update
+ *
+ * There may be a few cases where you would need to gracefully interrupt
+ * the update process in order to prevent the remaining observers from being
+ * notified. The following example will demonstrate how an observer is able
+ * to interrupt a subject in the middle of an update.
+ *
+ *     use Phine\Observer\Exception\ReasonException;
+ *
+ *     class InterruptingObserver implements ObserverInterface
+ *     {
+ *         private $badConditionMet = false;
+ *
+ *         public function badConditionMet()
+ *         {
+ *             $this->badConditionMet = true;
+ *         }
+ *
+ *         public function receiveUpdate(SubjectInterface $subject)
+ *         {
+ *             if ($this->badConditionMet) {
+ *                 $subject->interruptUpdate(
+ *                     new ReasonException('It is an example.')
+ *                 );
+ *             }
+ *
+ *             // otherwise do work
+ *         }
+ *     }
+ *
+ * Using the new `InterruptingObserver` class with the `MyObserver` class,
+ * you can see how the subject will halt an update that is in progress.
+ *
+ *     $observer = new InterruptingObserver();
+ *     $observer->badConditionMet();
+ *
+ *     $subject->registerObserver(new MyObserver('A'));
+ *     $subject->registerObserver($observer);
+ *     $subject->registerObserver(new MyObserver('B'));
+ *
+ *     $subject->notifyObservers();
+ *
+ * When the observers are notified, you will only see the following output:
+ *
+ *     Updated: A
+ *     PHP Fatal error:  Uncaught exception 'Phine\Observer\Exception\ReasonException' with message 'It is an example.'
+ *     ...
+ *
+ * While passing an instance of `ReasonException` to `interruptUpdate()` is
+ * not required, I strongly advise that you do provide one. Doing so will make
+ * it clear to a developer why an update was interrupted, ideally eliminating
+ * the need to dig through the stack trace to find more information about why
+ * an interrupt was done.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ *
+ * @api
+ */
+interface SubjectInterface
+{
+    /**
+     * The first priority for an observer.
+     *
+     * @api
+     */
+    const FIRST_PRIORITY = 0;
+
+    /**
+     * The last priority for an observer.
+     *
+     * @api
+     */
+    const LAST_PRIORITY = PHP_INT_MAX;
+
+    /**
+     * Copies observers from another subject.
+     *
+     * This method will register the observers of another subject with this
+     * subject, maintain their priority and the order they were registered in.
+     * Note, however, that they will be called after any observers that have
+     * already been registered with this subject.
+     *
+     *     // $subject has a copy of the observers from $anotherSubject
+     *     $subject->copyObservers($anotherSubject);
+     *
+     * @param SubjectInterface $subject A subject to copy from.
+     *
+     * @api
+     */
+    public function copyObservers(SubjectInterface $subject);
+
+    /**
+     * Returns the reason the last update was interrupted.
+     *
+     * This method will return the reason the last update this subject made
+     * was interrupted. Note that if there has yet to be an update, or if the
+     * last update was not interrupted, nothing is returned.
+     *
+     *     $reason = $subject->getInterruptReason();
+     *
+     * @return ReasonException If the previous update was interrupted, the
+     *                         exception representing the reason is returned.
+     *                         If no interrupt had occurred, nothing (`null`)
+     *                         is returned.
+     *
+     * @api
+     */
+    public function getInterruptReason();
+
+    /**
+     * Returns the observers registered to this subject.
+     *
+     * This method will return a list of observers in the order they would
+     * be updated by the subject. The list is an array of arrays, where the
+     * key of the outer array is the priority number, and the inner array
+     * for each priority contains the list of observers in the order they
+     * have been registered.
+     *
+     *     $observers = $subject->getObservers();
+     *
+     * The returned list would look something like the following:
+     *
+     *     $observers = array(
+     *         0 => array(
+     *             $observer1,
+     *             $observer2,
+     *         ),
+     *         123 => array(
+     *             $observer3
+     *         ),
+     *         456 => array(
+     *             $observer4
+     *         ),
+     *     );
+     *
+     * @return array The list of observers and their priorities.
+     *
+     * @api
+     */
+    public function getObservers();
+
+    /**
+     * Checks if a specific observer is registered with this subject.
+     *
+     * This method will check if the given observer is registered with this
+     * subject. If a `$priority` is specified, this method will only check
+     * if the given observer was registered with the specified priority.
+     *
+     *     $subject->registerObserver($observer, 123);
+     *
+     *     if ($subject->hasObserver($observer)) {
+     *         // registered
+     *     }
+     *
+     *     if ($subject->hasObserver($observer, 123)) {
+     *         // registered with priority 123
+     *     }
+     *
+     *     if (!$subject->hasObserver($observer, 456)) {
+     *         // not registered with priority 456
+     *     }
+     *
+     * @param ObserverInterface $observer The observer to check for.
+     * @param integer           $priority The priority to limit the check to.
+     *
+     * @return boolean If the observer is registered, `true` is returned. If
+     *                 the observer is not registered, `false` is returned.
+     *
+     * @api
+     */
+    public function hasObserver(ObserverInterface $observer, $priority = null);
+
+    /**
+     * Checks if this subject has any observers registered.
+     *
+     * This method will check to see if this subject has any observers
+     * registered, regardless of priority. If a `$priority` is specified, this
+     * method will only check to see if any observer has been registered with
+     * the specified priority.
+     *
+     *     $subject->registerObserver($observer, 123);
+     *
+     *     if ($subject->hasObservers()) {
+     *         // registered
+     *     }
+     *
+     *     if (!$subject->hasObserver(456)) {
+     *        // none registered with priority 456
+     *     }
+     *
+     * @param integer $priority The priority to limit the check to.
+     *
+     * @return boolean If there are one or more observer registered, `true`
+     *                 is returned. If there are no observers registered,
+     *                 `false` is returned.
+     *
+     * @api
+     */
+    public function hasObservers($priority = null);
+
+    /**
+     * Interrupts the observer update process.
+     *
+     * This method will interrupt an update that is currently in progress.
+     * If a `$reason` is not provided, a default one will be created. If an
+     * update is currently not in progress, an exception will be thrown.
+     *
+     *     class MyObserver implements ObserverInterface
+     *     {
+     *         public function receiveUpdate(SubjectInterface $subject)
+     *         {
+     *             $subject->interruptUpdate(new ReasonException('My reason.'));
+     *         }
+     *     }
+     *
+     * @param ReasonException $reason A reason for the interruption.
+     *
+     * @throws SubjectException If an update is not in progress.
+     *
+     * @api
+     */
+    public function interruptUpdate(ReasonException $reason = null);
+
+    /**
+     * Checks if the last update was interrupted.
+     *
+     * This method will check to see if the last update was interrupted.
+     *
+     *     if ($subject->isInterrupted()) {
+     *         // it was interrupted
+     *     }
+     *
+     * @return boolean If the last update was interrupted, `true` is returned.
+     *                 If the last update was not interrupted, `false` is
+     *                 returned.
+     *
+     * @api
+     */
+    public function isInterrupted();
+
+    /**
+     * Checks if the subject is in the process of updating its observers.
+     *
+     * This method will check if the subject is in the process of updating
+     * its registered observers.
+     *
+     *     if ($subject->isUpdating()) {
+     *         // currently updating
+     *     }
+     *
+     * @return boolean If the subject is currently updating its observers,
+     *                 `true` is returned. If the subject is not currently
+     *                 updating its observers, `false` is returned.
+     *
+     * @api
+     */
+    public function isUpdating();
+
+    /**
+     * Notifies all observers of an update from this subject.
+     *
+     * This method will update all observers that have been registered with
+     * this subject. The observers will first be updated in the order they
+     * have been prioritized, from `SubjectInterface::FIRST_PRIORITY` (zero)
+     * to `SubjectInterface::LAST_PRIORITY` (`PHP_INT_MAX`). If the update
+     * is interrupted by an observer, an exception will be thrown.
+     *
+     * If an update is already in progress, an exception will be thrown.
+     *
+     *     try {
+     *         $subject->notifyObservers();
+     *     } catch (ReasonException $exception) {
+     *         // the update was interrupted
+     *     } catch (SubjectException $exception) {
+     *         // already updating observers
+     *     }
+     *
+     *     if (!$subject->isInterrupted()) {
+     *         // only do something if not interrupted
+     *     }
+     *
+     * @return mixed While not required, a subject may return a value once
+     *               all of the observers have been notified. If no value is
+     *               available, `null` is always returned.
+     *
+     * @throws ReasonException  If the update is interrupted.
+     * @throws SubjectException If the subject is already updating.
+     *
+     * @api
+     */
+    public function notifyObservers();
+
+    /**
+     * Registers an observer with this subject.
+     *
+     * This method will register a single occurrence of the given `$observer`
+     * with this subject. Multiple registrations of the same observer may be
+     * done. By default, the `SubjectInterface::FIRST_PRIORITY` priority is
+     * used for the registration.
+     *
+     *     $subject->registerObserver($observer, 123);
+     *     $subject->registerObserver($observer, 456);
+     *     $subject->registerObserver($observer, 789);
+     *
+     * The priority may be anywhere from `0` (zero) to `PHP_INT_MAX`. Observers
+     * are updated beginning with `0` and ending with `PHP_INT_MAX`. Multiple
+     * observers, even the same observer, may be registered using the same
+     * priority.
+     *
+     * For convenience, the following constants are made available:
+     *
+     * - `SubjectInterface::FIRST_PRIORITY` &mdash; Priority `0` (zero).
+     * - `SubjectInterface::LAST_PRIORITY` &mdash; Priority `PHP_INT_MAX`.
+     *
+     * @param ObserverInterface $observer The observer to register.
+     * @param integer           $priority The priority of the observer.
+     *
+     * @api
+     */
+    public function registerObserver(
+        ObserverInterface $observer,
+        $priority = self::FIRST_PRIORITY
+    );
+
+    /**
+     * Replaces the observers for this subject using observers from another.
+     *
+     * This method will replace the observers of this subject with the
+     * observers registered with the given subject, preserving priority and
+     * registration order. Any previous observers registered with this subject
+     * will be forgotten.
+     *
+     *     // $subject will have the observers of $anotherSubject
+     *     $subject->replaceObservers($anotherSubject);
+     *
+     * @param SubjectInterface $subject A subject to replace with.
+     *
+     * @api
+     */
+    public function replaceObservers(SubjectInterface $subject);
+
+    /**
+     * Unregisters some or all observers from this subject.
+     *
+     * This method will unregister some or all observers and each occurrence
+     * of their registration, depending on the parameters that have been
+     * provided.
+     *
+     * - By default, unregisters all occurrences of all observers of all
+     *   priorities.
+     * - If an `$observer` is provided, unregisters all occurrences of only
+     *   the given observer of all priorities.
+     * - If a `$priority` is specified, unregisters all occurrences of all
+     *   observers only with the specified priority.
+     * - If both `$observer` and `$priority` is specified, unregisters all
+     *   occurrences of the given observer with the specified priority.
+     *
+     *     // all gone
+     *     $subject->unregisterAllObservers();
+     *
+     *     // all $observer gone
+     *     $subject->unregisterAllObservers($observer);
+     *
+     *     // all with 123 priority gone
+     *     $subject->unregisterAllObservers(null, 123);
+     *
+     *     // all $observer with priority 123 gone
+     *     $subject->unregisterAllObservers($observer, 123);
+     *
+     * @param ObserverInterface $observer The observer to unregister.
+     * @param integer           $priority The priority to limit to.
+     *
+     * @api
+     */
+    public function unregisterAllObservers(
+        ObserverInterface $observer = null,
+        $priority = null
+    );
+
+    /**
+     * Unregisters an observer from this subject.
+     *
+     * This method will unregister all occurrences of this observer from this
+     * subject. If a `$priority` is specified all occurrences will be removed
+     * only with the specified priority.
+     *
+     *     // all gone
+     *     $subject->unregisterObserver($observer);
+     *
+     *     // all with 123 priority gone
+     *     $subject->unregisterObserver($observer, 123);
+     *
+     * @param ObserverInterface $observer The observer to unregister.
+     * @param integer           $priority The priority to limit to.
+     *
+     * @api
+     */
+    public function unregisterObserver(
+        ObserverInterface $observer,
+        $priority = null
+    );
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Test/Observer.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Test/Observer.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Phine\Observer\Test;
+
+use Phine\Observer\Exception\ReasonException;
+use Phine\Observer\ObserverInterface;
+use Phine\Observer\SubjectInterface;
+use Phine\Test\Property;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * A simple test observer.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class Observer implements ObserverInterface
+{
+    /**
+     * The order counter (must reset before update).
+     *
+     * @var integer
+     */
+    public static $counter = 0;
+
+    /**
+     * Perform a double update?
+     *
+     * @var boolean
+     */
+    private $double = false;
+
+    /**
+     * The order in which it was called.
+     *
+     * @var integer
+     */
+    public $order;
+
+    /**
+     * The reason for the interrupt.
+     *
+     * @var ReasonException
+     */
+    public $reason;
+
+    /**
+     * The subject that updated this observer.
+     *
+     * @var SubjectInterface
+     */
+    public $subject;
+
+    /**
+     * The flag used to determine if the update should be interrupted.
+     *
+     * @var boolean
+     */
+    private $interrupt;
+
+    /**
+     * The test case.
+     *
+     * @var TestCase
+     */
+    private $test;
+
+    /**
+     * Sets the interrupt flag.
+     *
+     * @param boolean  $interrupt Interrupt the update?
+     * @param TestCase $test      The test case.
+     * @param boolean  $double    Perform a double update?
+     */
+    public function __construct(
+        $interrupt = false,
+        TestCase $test = null,
+        $double = false
+    ) {
+        $this->double = $double;
+        $this->interrupt = $interrupt;
+        $this->test = $test;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function receiveUpdate(SubjectInterface $subject)
+    {
+        $this->order = self::$counter++;
+
+        $this->subject = $subject;
+
+        if ($this->double) {
+            $subject->notifyObservers();
+        }
+
+        if ($this->test) {
+            $this->test->assertTrue(
+                Property::get($subject, 'updating'),
+                'The subject should be updating.'
+            );
+        }
+
+        if ($this->interrupt) {
+            $this->reason = new ReasonException('Testing interruption.');
+
+            $subject->interruptUpdate($this->reason);
+        }
+    }
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Tests/ArrayCollectionTest.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Tests/ArrayCollectionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Phine\Observer\Tests;
+
+use Phine\Observer\ArrayCollection;
+use Phine\Observer\Subject;
+use Phine\Test\Property;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests the methods in the {@link ArrayCollection} class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class ArrayCollectionTest extends TestCase
+{
+    /**
+     * The array collection to test.
+     *
+     * @var ArrayCollection
+     */
+    private $collection;
+
+    /**
+     * Make sure we can check if a subject is registered.
+     */
+    public function testOffsetExists()
+    {
+        $this->assertFalse(
+            isset($this->collection['test']),
+            'Make sure the "test" subject is not registered.'
+        );
+
+        Property::set($this->collection, 'subjects', array('test' => new Subject()));
+
+        $this->assertTrue(
+            isset($this->collection['test']),
+            'Make sure the "test" subject is registered.'
+        );
+    }
+
+    /**
+     * Make sure we can get get a registered subject.
+     */
+    public function testOffsetGet()
+    {
+        $subject = new Subject();
+
+        Property::set($this->collection, 'subjects', array('test' => $subject));
+
+        $this->assertSame(
+            $subject,
+            $this->collection['test'],
+            'Make sure we get back the same "test" subject.'
+        );
+    }
+
+    /**
+     * Make sure that we can register and replace a subject.
+     */
+    public function testOffsetSet()
+    {
+        $subject = new Subject();
+
+        $this->collection['test'] = $subject;
+
+        $this->assertSame(
+            array('test' => $subject),
+            Property::get($this->collection, 'subjects'),
+            'Make sure that the "test" subject is set.'
+        );
+
+        $new = new Subject();
+
+        $this->collection['test'] = $new;
+
+        $this->assertSame(
+            array('test' => $new),
+            Property::get($this->collection, 'subjects'),
+            'Make sure that the "test" subject is replaced.'
+        );
+    }
+
+    /**
+     * Make sure that we can unregister a subject.
+     */
+    public function testOffsetUnset()
+    {
+        $subject = new Subject();
+
+        Property::set($this->collection, 'subjects', array('test' => $subject));
+
+        unset($this->collection['test']);
+        unset($this->collection['test']); // should not thrown an exception
+
+        $this->assertSame(
+            array(),
+            Property::get($this->collection, 'subjects'),
+            'Make sure the "test" subject is unregistered.'
+        );
+    }
+
+    /**
+     * Creates a new instance of {@link ArrayCollection} for testing.
+     */
+    protected function setUp()
+    {
+        $this->collection = new ArrayCollection();
+    }
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Tests/CollectionTest.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Tests/CollectionTest.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace Phine\Observer\Tests;
+
+use Phine\Observer\Collection;
+use Phine\Observer\Subject;
+use Phine\Observer\Test\Observer;
+use Phine\Test\Property;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests the methods in the {@link Collection} class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class CollectionTest extends TestCase
+{
+    /**
+     * The collection to test.
+     *
+     * @var Collection
+     */
+    private $collection;
+
+    /**
+     * Make sure that we can copy the subjects of another collection.
+     */
+    public function testCopySubjects()
+    {
+        $a = new Subject();
+        $b = new Subject();
+        $c = new Subject();
+        $d = new Subject();
+
+        Property::set(
+            $this->collection,
+            'subjects',
+            array(
+                'b' => $b
+            )
+        );
+
+        $collection = new Collection();
+
+        Property::set(
+            $collection,
+            'subjects',
+            array(
+                'a' => $a,
+                'b' => $c,
+                'c' => $d
+            )
+        );
+
+        $this->collection->copySubjects($collection);
+
+        $this->assertSame(
+            array(
+                'b' => $c,
+                'a' => $a,
+                'c' => $d,
+            ),
+            Property::get($this->collection, 'subjects'),
+            'The subjects should have been copied correctly.'
+        );
+    }
+
+    /**
+     * Make sure that we can retrieve a registered subject.
+     */
+    public function testGetSubject()
+    {
+        $subject = new Subject();
+
+        Property::set($this->collection, 'subjects', array('test' => $subject));
+
+        $this->assertSame(
+            $subject,
+            $this->collection->getSubject('test'),
+            'Make sure we get back the same subject.'
+        );
+    }
+
+    /**
+     * Make sure that an exception is thrown if the subject is not registered.
+     */
+    public function testGetSubjectNotRegistered()
+    {
+        $this->setExpectedException(
+            'Phine\\Observer\\Exception\\CollectionException',
+            'The "test" subject unique identifier is not in use.'
+        );
+
+        $this->collection->getSubject('test');
+    }
+
+    /**
+     * Make sure that we can retrieve the registered subjects.
+     */
+    public function testGetSubjects()
+    {
+        $subjects = array(
+            'a' => new Subject(),
+            'b' => new Subject(),
+            'c' => new Subject(),
+        );
+
+        Property::set($this->collection, 'subjects', $subjects);
+
+        $this->assertSame(
+            $subjects,
+            $this->collection->getSubjects(),
+            'The list of subjects should be returned.'
+        );
+    }
+
+    /**
+     * Make sure we can check if a subject is registered.
+     */
+    public function testIsSubjectRegistered()
+    {
+        $this->assertFalse(
+            $this->collection->isSubjectRegistered('test'),
+            'Make sure the "test" subject is not registered.'
+        );
+
+        Property::set(
+            $this->collection,
+            'subjects',
+            array('test' => new Subject())
+        );
+
+        $this->assertTrue(
+            $this->collection->isSubjectRegistered('test'),
+            'Make sure the "test" subject is registered.'
+        );
+    }
+
+    /**
+     * Make sure we can register a subject.
+     */
+    public function testRegisterSubject()
+    {
+        $subject = new Subject();
+
+
+        $this->collection->registerSubject('test', $subject);
+
+        $this->assertSame(
+            array('test' => $subject),
+            Property::get($this->collection, 'subjects'),
+            'Make sure that the "test" subject is registered.'
+        );
+    }
+
+    /**
+     * Make sure an exception is thrown if the subject is already registered.
+     */
+    public function testRegisterSubjectDuplicate()
+    {
+        $subject = new Subject();
+
+        $this->collection->registerSubject('test', $subject);
+
+        $this->setExpectedException(
+            'Phine\\Observer\\Exception\\CollectionException',
+            'The "test" subject unique identifier is already in use.'
+        );
+
+        $this->collection->registerSubject('test', $subject);
+    }
+
+    /**
+     * Make sure that we can replace a registered subject.
+     */
+    public function testReplaceSubject()
+    {
+        $subject = new Subject();
+
+        Property::set($this->collection, 'subjects', array('test' => $subject));
+
+        $new = new Subject();
+
+        $this->collection->replaceSubject('test', $new);
+
+        $this->assertSame(
+            array('test' => $new),
+            Property::get($this->collection, 'subjects'),
+            'Make sure the "test" subject is replaced.'
+        );
+    }
+
+    /**
+     * Make sure an exception is thrown if we replace a non-existent subject.
+     */
+    public function testReplaceSubjectNotRegistered()
+    {
+        $subject = new Subject();
+
+        $this->setExpectedException(
+            'Phine\\Observer\\Exception\\CollectionException',
+            'The "test" subject unique identifier is not in use.'
+        );
+
+        $this->collection->replaceSubject('test', $subject);
+    }
+
+    /**
+     * Make sure that we can replace the subjects using another collection.
+     */
+    public function testReplaceSubjects()
+    {
+        $a = new Subject();
+        $b = new Subject();
+        $c = new Subject();
+        $d = new Subject();
+
+        Property::set(
+            $this->collection,
+            'subjects',
+            array(
+                'a' => $a
+            )
+        );
+
+        $collection = new Collection();
+
+        Property::set(
+            $collection,
+            'subjects',
+            array(
+                'b' => $b,
+                'c' => $c,
+                'd' => $d
+            )
+        );
+
+        $this->collection->replaceSubjects($collection);
+
+        $this->assertSame(
+            array(
+                'b' => $b,
+                'c' => $c,
+                'd' => $d,
+            ),
+            Property::get($this->collection, 'subjects'),
+            'The subjects should have been replaced.'
+        );
+    }
+
+    /**
+     * Make sure that we can unregister a subject.
+     */
+    public function testUnregisterSubject()
+    {
+        Property::set($this->collection, 'subjects', array('test' =>  new Subject()));
+
+        $this->collection->unregisterSubject('test');
+
+        $this->assertSame(
+            array(),
+            Property::get($this->collection, 'subjects'),
+            'Make sure the "test" subject is unregistered.'
+        );
+    }
+
+    /**
+     * Make sure an exception is thrown if we unregister an unregistered subject.
+     */
+    public function testUnregisterSubjectNotRegistered()
+    {
+        $this->setExpectedException(
+            'Phine\\Observer\\Exception\\CollectionException',
+            'The "test" subject unique identifier is not in use.'
+        );
+
+        $this->collection->unregisterSubject('test');
+    }
+
+    /**
+     * Creates a new collection to test.
+     */
+    protected function setUp()
+    {
+        $this->collection = new Collection();
+    }
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Tests/Exception/CollectionExceptionTest.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Tests/Exception/CollectionExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Phine\Observer\Tests\Exception;
+
+use Phine\Observer\Exception\CollectionException;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests the methods for the {@link CollectionException} class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class CollectionExceptionTest extends TestCase
+{
+    /**
+     * Make sure we get the message we are expecting.
+     */
+    public function testIdNotUsed()
+    {
+        $this->assertEquals(
+            'The "test" subject unique identifier is not in use.',
+            CollectionException::idNotUsed('test')->getMessage(),
+            'Make sure we get the right message.'
+        );
+    }
+
+    /**
+     * Make sure we get the message we are expecting.
+     */
+    public function testIdUsed()
+    {
+        $this->assertEquals(
+            'The "test" subject unique identifier is already in use.',
+            CollectionException::idUsed('test')->getMessage(),
+            'Make sure we get the right message.'
+        );
+    }
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Tests/Exception/ReasonExceptionTest.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Tests/Exception/ReasonExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Phine\Observer\Tests\Exception;
+
+use Phine\Observer\Exception\ReasonException;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests the methods for the {@link ReasonException} class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class ReasonExceptionTest extends TestCase
+{
+    /**
+     * Make sure that we get the message we are expecting.
+     */
+    public function testNotSpecified()
+    {
+        $this->assertEquals(
+            '(no reason specified)',
+            ReasonException::notSpecified()->getMessage(),
+            'Make sure we get the right message.'
+        );
+    }
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Tests/Exception/SubjectExceptionTest.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Tests/Exception/SubjectExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Phine\Observer\Tests\Exception;
+
+use Phine\Observer\Exception\SubjectException;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests the methods for the `SubjectException` class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class SubjectExceptionTest extends TestCase
+{
+    /**
+     * Make sure that we get the message we are expecting.
+     */
+    public function testAlreadyUpdating()
+    {
+        $this->assertEquals(
+            'There is already an update in progress.',
+            SubjectException::alreadyUpdating()->getMessage(),
+            'Make sure we get the right message.'
+        );
+    }
+
+    /**
+     * Make sure that we get the message we are expecting.
+     */
+    public function testNotUpdating()
+    {
+        $this->assertEquals(
+            'There is no update in progress to interrupt.',
+            SubjectException::notUpdating()->getMessage(),
+            'Make sure we get the right message.'
+        );
+    }
+}

--- a/lib/phine/observer/src/tests/Phine/Observer/Tests/SubjectTest.php
+++ b/lib/phine/observer/src/tests/Phine/Observer/Tests/SubjectTest.php
@@ -1,0 +1,541 @@
+<?php
+
+namespace Phine\Observer\Tests;
+
+use Phine\Observer\Exception\ReasonException;
+use Phine\Observer\Exception\SubjectException;
+use Phine\Observer\Subject;
+use Phine\Observer\Test\Observer;
+use Phine\Test\Property;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Tests the methods for the {@link Subject} class.
+ *
+ * @author Kevin Herrera <kevin@herrera.io>
+ */
+class SubjectTest extends TestCase
+{
+    /**
+     * The subject to test.
+     *
+     * @var Subject
+     */
+    private $subject;
+
+    /**
+     * Make sure that we can copy the observers of another subject.
+     */
+    public function testCopyObservers()
+    {
+        $a = new Observer();
+        $b = new Observer();
+        $c = new Observer();
+        $d = new Observer();
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                123 => array($a),
+            )
+        );
+
+        $another = new Subject();
+
+        Property::set(
+            $another,
+            'observers',
+            array(
+                0 => array($b),
+                123 => array($c),
+                456 => array($d),
+            )
+        );
+
+        $this->subject->copyObservers($another);
+
+        $this->assertSame(
+            array(
+                123 => array($a, $c),
+                0 => array($b),
+                456 => array($d),
+            ),
+            Property::get($this->subject, 'observers'),
+            'The observers should have been copied correctly.'
+        );
+    }
+
+    /**
+     * Make sure that we can get the reason for the interrupted update.
+     */
+    public function testGetInterruptReason()
+    {
+        $reason = ReasonException::notSpecified();
+
+        Property::set($this->subject, 'reason', $reason);
+
+        $this->assertSame(
+            $reason,
+            $this->subject->getInterruptReason(),
+            'Make sure we can retrieve the reason for the interrupted update.'
+        );
+    }
+
+    /**
+     * Make sure that we can retrieve the registered observers.
+     */
+    public function testGetObservers()
+    {
+        $observers = array(
+            0 => array(new Observer()),
+            123 => array(new Observer(), new Observer()),
+            456 => array(new Observer()),
+        );
+
+        Property::set($this->subject, 'observers', $observers);
+
+        $this->assertSame(
+            $observers,
+            $this->subject->getObservers(),
+            'The same observers should be returned.'
+        );
+    }
+
+    /**
+     * Make sure that we can check if an observer is registered.
+     */
+    public function testHasObserver()
+    {
+        $observer = new Observer();
+
+        $this->assertFalse(
+            $this->subject->hasObserver($observer),
+            'Make sure we do not find the observer in a new subject.'
+        );
+
+        Property::set($this->subject, 'observers', array(array($observer)));
+
+        $this->assertTrue(
+            $this->subject->hasObserver($observer),
+            'Make sure we can confirm that an observer is registered.'
+        );
+
+        $this->assertFalse(
+            $this->subject->hasObserver($observer, 123),
+            'Make sure that using a different priority returns false.'
+        );
+
+        $this->assertTrue(
+            $this->subject->hasObserver($observer, 0),
+            'Make sure that using the same priority returns true.'
+        );
+    }
+
+    /**
+     * Make sure that we can check if any observer is registered.
+     */
+    public function testHasObservers()
+    {
+        Property::set($this->subject, 'observers', array(123 => array()));
+
+        $this->assertFalse(
+            $this->subject->hasObservers(),
+            'Make sure that no observers are registered with a new subject.'
+        );
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(123 => array(new Observer()))
+        );
+
+        $this->assertTrue(
+            $this->subject->hasObservers(),
+            'Make sure that checking any priority returns true if registered.'
+        );
+
+        $this->assertFalse(
+            $this->subject->hasObservers(0),
+            'Make sure that unused priorities return false.'
+        );
+
+        $this->assertTrue(
+            $this->subject->hasObservers(123),
+            'Make sure that used priorities return true.'
+        );
+    }
+
+    /**
+     * Make sure that we can interrupt an update.
+     */
+    public function testInterruptUpdate()
+    {
+        Property::set($this->subject, 'updating', true);
+
+        $this->subject->interruptUpdate();
+
+        $this->assertEquals(
+            '(no reason specified)',
+            Property::get($this->subject, 'reason')->getMessage(),
+            'Make sure that a default reason is used if none is given.'
+        );
+
+        $reason = new ReasonException('Just testing.');
+
+        Property::set($this->subject, 'updating', true);
+
+        $this->subject->interruptUpdate($reason);
+
+        $this->assertSame(
+            $reason,
+            Property::get($this->subject, 'reason'),
+            'Make sure that we can use our own reason for interrupting.'
+        );
+
+        $this->assertFalse(
+            Property::get($this->subject, 'updating'),
+            'The subject should no longer be in the updating state.'
+        );
+
+        $this->setExpectedException(
+            'Phine\\Observer\\Exception\\SubjectException',
+            'There is no update in progress to interrupt.'
+        );
+
+        $this->subject->interruptUpdate();
+    }
+
+    /**
+     * Make sure that we can check if an update was interrupted.
+     */
+    public function testIsInterrupted()
+    {
+        $this->assertFalse(
+            $this->subject->isInterrupted(),
+            'By default, the subject should not be interrupted.'
+        );
+
+        Property::set($this->subject, 'reason', new ReasonException());
+
+        $this->assertTrue(
+            $this->subject->isInterrupted(),
+            'The subject should now be interrupted.'
+        );
+    }
+
+    /**
+     * Make sure that sure can check if an update is in progress.
+     */
+    public function testIsUpdating()
+    {
+        $this->assertFalse(
+            $this->subject->isUpdating(),
+            'By default, the subject should not be in the updating state.'
+        );
+
+        Property::set($this->subject, 'updating', true);
+
+        $this->assertTrue(
+            $this->subject->isUpdating(),
+            'The subject should now be in the updating state.'
+        );
+    }
+
+    /**
+     * Make sure that we can notify all registered observers.
+     */
+    public function testNotifyObservers()
+    {
+        // perform a regular update
+        Observer::$counter = 0;
+
+        $observers = array(
+            array(new Observer(false, $this), 2),
+            array(new Observer(false, $this), 0),
+            array(new Observer(false, $this), 1),
+        );
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                0 => array($observers[1][0]),
+                123 => array($observers[2][0], $observers[0][0]),
+            )
+        );
+
+        $this->subject->notifyObservers();
+
+        $this->assertFalse(
+            Property::get($this->subject, 'updating'),
+            'The subject should no longer be updating.'
+        );
+
+        foreach ($observers as $i => $observer) {
+            $this->assertSame(
+                $this->subject,
+                $observer[0]->subject,
+                "Make sure that observer #$i has the same subject."
+            );
+
+            $this->assertEquals(
+                $observer[1],
+                $observer[0]->order,
+                "Make sure that observer #$i is called {$observer[1]}st/rd/th."
+            );
+        }
+
+        // perform an interrupted update
+        $observers = array(
+            array(new Observer(), null),
+            array(new Observer(), 3),
+            array(new Observer(true), 4),
+        );
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                0 => array($observers[1][0]),
+                123 => array($observers[2][0], $observers[0][0]),
+            )
+        );
+        try {
+            $this->subject->notifyObservers();
+        } catch (ReasonException $reason) {
+        }
+
+        foreach ($observers as $i => $observer) {
+            $this->assertEquals(
+                $observer[1],
+                $observer[0]->order,
+                "Make sure that observer #$i is called {$observer[1]}st/rd/th or not at all."
+            );
+        }
+
+        $this->assertTrue(
+            isset($reason),
+            'Make sure that the update was interrupted.'
+        );
+
+        $this->assertNotNull(
+            Property::get($this->subject, 'reason'),
+            'The interrupt reason should be set.'
+        );
+
+        $this->assertFalse(
+            Property::get($this->subject, 'updating'),
+            'The subject should no longer be updating.'
+        );
+
+        // perform a double update
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                0 => array(new Observer(false, null, true)),
+            )
+        );
+        try {
+            $this->subject->notifyObservers();
+        } catch (SubjectException $exception) {
+        }
+
+        $this->assertTrue(
+            isset($exception),
+            'Make sure that the double update was done.'
+        );
+
+        $this->assertFalse(
+            Property::get($this->subject, 'updating'),
+            'The subject should no longer be updating.'
+        );
+    }
+
+    /**
+     * Make sure that we can register an observer.
+     */
+    public function testRegisterObserver()
+    {
+        $observer = new Observer();
+
+        $this->subject->registerObserver($observer);
+
+        $this->assertEquals(
+            array(
+                0 => array($observer)
+            ),
+            Property::get($this->subject, 'observers'),
+            'Make sure the observer is registered as zero priority.'
+        );
+
+        $this->subject->registerObserver($observer, 123);
+
+        $this->assertEquals(
+            array(
+                0 => array($observer),
+                123 => array($observer)
+            ),
+            Property::get($this->subject, 'observers'),
+            'Make sure that the observer is registered with priority 123.'
+        );
+    }
+
+    /**
+     * Make sure that we can replace all registered observers using another subject.
+     */
+    public function testReplaceObservers()
+    {
+        $a = new Observer();
+        $b = new Observer();
+        $c = new Observer();
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                123 => array(new Observer()),
+            )
+        );
+
+        $another = new Subject();
+
+        Property::set(
+            $another,
+            'observers',
+            array(
+                0 => array($a),
+                123 => array($b),
+                456 => array($c),
+            )
+        );
+
+        $this->subject->replaceObservers($another);
+
+        $this->assertSame(
+            Property::get($another, 'observers'),
+            Property::get($this->subject, 'observers'),
+            'The observers should have been copied correctly.'
+        );
+    }
+
+    /**
+     * Make sure that we can unregister all observers.
+     */
+    public function testUnregisterAllObservers()
+    {
+        $observers = array(
+            new Observer(),
+            new Observer(),
+            new Observer(),
+        );
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                0 => array($observers[0], $observers[1]),
+                123 => array($observers[0], $observers[1], $observers[2], $observers[1]),
+                456 => array($observers[2], $observers[2]),
+            )
+        );
+
+        $this->subject->unregisterAllObservers($observers[1], 123);
+
+        $this->assertSame(
+            array(
+                0 => array($observers[0], $observers[1]),
+                123 => array($observers[0], 2 => $observers[2]),
+                456 => array($observers[2], $observers[2]),
+            ),
+            Property::get($this->subject, 'observers'),
+            'Make sure that all of a single observer is unregistered in a specific priority.'
+        );
+
+        $this->subject->unregisterAllObservers($observers[2]);
+
+        $this->assertSame(
+            array(
+                0 => array($observers[0], $observers[1]),
+                123 => array($observers[0]),
+                456 => array(),
+            ),
+            Property::get($this->subject, 'observers'),
+            'Make sure that all of a single observer is unregistered for any priority.'
+        );
+
+        $this->subject->unregisterAllObservers(null, 0);
+
+        $this->assertSame(
+            array(
+                123 => array($observers[0]),
+                456 => array(),
+            ),
+            Property::get($this->subject, 'observers'),
+            'Make sure that all observers of a single priority are unregistered.'
+        );
+
+        $this->subject->unregisterAllObservers();
+
+        $this->assertSame(
+            array(),
+            Property::get($this->subject, 'observers'),
+            'Make sure that all observers are unregistered.'
+        );
+    }
+
+    /**
+     * Make sure that we can unregister a single occurrences of an observer.
+     */
+    public function testUnregisterObserver()
+    {
+        $observers = array(
+            new Observer(),
+            new Observer(),
+            new Observer(),
+        );
+
+        Property::set(
+            $this->subject,
+            'observers',
+            array(
+                456 => array($observers[2], $observers[2]),
+                0 => array($observers[0], $observers[1]),
+                123 => array($observers[0], $observers[1], $observers[2], $observers[1]),
+            )
+        );
+
+        $this->subject->unregisterObserver($observers[0]);
+
+        $this->assertSame(
+            array(
+                0 => array(1 => $observers[1]),
+                123 => array($observers[0], $observers[1], $observers[2], $observers[1]),
+                456 => array($observers[2], $observers[2]),
+            ),
+            Property::get($this->subject, 'observers'),
+            'Unregister the first occurrence sorted by priority.'
+        );
+
+        $this->subject->unregisterObserver($observers[2], 456);
+
+        $this->assertSame(
+            array(
+                0 => array(1 => $observers[1]),
+                123 => array($observers[0], $observers[1], $observers[2], $observers[1]),
+                456 => array(1 => $observers[2]),
+            ),
+            Property::get($this->subject, 'observers'),
+            'Unregister the first occurrence for a specific priority.'
+        );
+    }
+
+    /**
+     * Creates a new {@link Subject} for testing.
+     */
+    protected function setUp()
+    {
+        $this->subject = new Subject();
+    }
+}

--- a/lib/phine/observer/src/tests/bootstrap.php
+++ b/lib/phine/observer/src/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+$loader = require __DIR__ . '/../vendors/autoload.php';
+$loader->add(null, __DIR__);

--- a/modules/useradd.php
+++ b/modules/useradd.php
@@ -29,6 +29,9 @@ $useradd = isset($_POST['useradd']) ? $_POST['useradd'] : array();
 
 if(sizeof($useradd))
 {
+    
+        $error = array();
+    
 	foreach($useradd as $key => $value)
 	    if (!is_array($value))
 		    $useradd[$key] = trim($value);
@@ -107,6 +110,12 @@ if(sizeof($useradd))
 	if (!empty($useradd['ntype']))
 		$useradd['ntype'] = array_sum(array_map('intval', $useradd['ntype']));
 
+        $hook_data = array(
+            'useradd' => $useradd,
+            'error' => $error
+        );
+        $error = $LMS->executeHook('useradd_validation_before_submit', $hook_data);
+        
 	if (!$error) {
 		$useradd['accessfrom'] = $accessfrom;
 		$useradd['accessto'] = $accessto;
@@ -128,6 +137,7 @@ if(sizeof($useradd))
 				}
 			}
 
+                $LMS->executeHook('useradd_after_submit', $id);
 		$SESSION->redirect('?m=userinfo&id='.$id);
 	} elseif (isset($_POST['selected']))
 		foreach ($_POST['selected'] as $idx => $name) {

--- a/modules/welcome.php
+++ b/modules/welcome.php
@@ -24,6 +24,8 @@
  *  $Id$
  */
 
+$LMS->executeHook('welcome_on_load');
+
 @include(LIB_DIR.'/locale/'.$_language.'/fortunes.php');
 
 $layout['pagetitle'] = 'LAN Management System';
@@ -57,6 +59,10 @@ if (!ConfigHelper::checkConfig('privileges.hide_summaries')) {
 	$SMARTY->assign('nodestats', $LMS->NodeStats());
 }
 
-$SMARTY->display('welcome.html');
+$template_file = 'welcome.html';
+
+$template_file = $LMS->executeHook('welcome_before_display', $template_file);
+
+$SMARTY->display($template_file);
 
 ?>

--- a/plugins/PluginExample/PluginExample.php
+++ b/plugins/PluginExample/PluginExample.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ *  LMS version 1.11-git
+ *
+ *  Copyright (C) 2001-2013 LMS Developers
+ *
+ *  Please, see the doc/AUTHORS for more information about authors!
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ *  $Id$
+ */
+
+use Phine\Observer\ObserverInterface;
+use Phine\Observer\SubjectInterface;
+
+/**
+ * PluginExample
+ *
+ * @author Maciej Lew <maciej.lew.1987@gmail.com>
+ */
+class PluginExample implements ObserverInterface
+{
+    protected $handlers;
+    
+    public function __construct() {
+        $this->handlers = array(
+            'welcome_on_load' => array(
+                'class' => 'WelcomeHandler',
+                'method' => 'welcomeOnLoad'
+            ),
+            'welcome_before_display' => array(
+                'class' => 'WelcomeHandler',
+                'method' => 'welcomeBeforeDisplay'
+            ),
+            'useradd_validation_before_submit' => array(
+                'class' => 'UseraddHandler',
+                'method' => 'useraddValidationBeforeSubmit'
+            ),
+            'useradd_after_submit' => array(
+                'class' => 'UseraddHandler',
+                'method' => 'useraddAfterSubmit'
+            ),
+        );
+    }
+    
+    public function receiveUpdate(SubjectInterface $lms_plugin_manager)
+    {
+        $hook_name = $lms_plugin_manager->getHookName();
+        $hook_data = $lms_plugin_manager->getHookData();
+        $new_hook_data = $this->dispatcher($hook_name, $hook_data);
+        $lms_plugin_manager->setHookData($new_hook_data);
+    }
+    
+    protected function dispatcher($hook_name, $hook_data)
+    {
+        if ($hook_name === null) {
+            throw new Exception('Hook name must be set!');
+        }
+        if (!is_array($this->handlers)) {
+            throw new Exception('Handlers must be set!');
+        }
+        if (array_key_exists($hook_name, $this->handlers)) {
+            if (!is_array($this->handlers[$hook_name])) {
+                throw new Exception("Wrong handler configuration format for hook '$hook_name'!");
+            }
+            $handler_class = $this->getHandlerClass($hook_name);
+            $handler_method = $this->getHandlerMethod($hook_name);
+            $handler = new $handler_class();
+            return $handler->$handler_method($hook_data);
+        }
+        
+    }
+    
+    protected function getHandlerClass($hook_name)
+    {
+        if (!isset($this->handlers[$hook_name]['class']) || !is_string($this->handlers[$hook_name]['class'])) {
+            throw new Exception("Wrong handler configuration format for hook '$hook_name'!");
+        } else {
+            return $this->handlers[$hook_name]['class'];
+        }
+    }
+    
+    protected function getHandlerMethod($hook_name)
+    {
+        if (!isset($this->handlers[$hook_name]['method']) || !is_string($this->handlers[$hook_name]['method'])) {
+            throw new Exception("Wrong handler configuration format for hook '$hook_name'!");
+        } else {
+            return $this->handlers[$hook_name]['method'];
+        }
+    }
+}

--- a/plugins/PluginExample/handlers/UseraddHandler.php
+++ b/plugins/PluginExample/handlers/UseraddHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ *  LMS version 1.11-git
+ *
+ *  Copyright (C) 2001-2013 LMS Developers
+ *
+ *  Please, see the doc/AUTHORS for more information about authors!
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ *  $Id$
+ */
+
+/**
+ * UseraddHandler
+ *
+ * @author Maciej Lew <maciej.lew.1987@gmail.com>
+ */
+class UseraddHandler
+{
+    /**
+     * Example of additional validation
+     * 
+     * @param mixed $hook_data
+     * @return mixed
+     */
+    public function useraddValidationBeforeSubmit($hook_data)
+    {
+        if (strpos($hook_data['useradd']['name'], 'X') !== 0) {
+            $hook_data['error']['name'] = 'Name must start with "X" ;-)';
+        }
+        return $hook_data['error'];
+    }
+    
+    /**
+     * Example of additional logging
+     * 
+     * @param mixed $hook_data
+     * @return null
+     */
+    public function useraddAfterSubmit($hook_data)
+    {
+        error_log("User with id $hook_data added");
+        return null;
+    }
+    
+}

--- a/plugins/PluginExample/handlers/WelcomeHandler.php
+++ b/plugins/PluginExample/handlers/WelcomeHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ *  LMS version 1.11-git
+ *
+ *  Copyright (C) 2001-2013 LMS Developers
+ *
+ *  Please, see the doc/AUTHORS for more information about authors!
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ *  $Id$
+ */
+
+/**
+ * WelcomeHandler
+ *
+ * @author Maciej Lew <maciej.lew.1987@gmail.com>
+ */
+class WelcomeHandler
+{
+    /**
+     * Example handler that does nothing
+     * 
+     * @param type $hook_data
+     */
+    public function welcomeOnLoad($hook_data)
+    {
+        error_log('welcome on load hook trigered');
+        return null;
+    }
+    
+    /**
+     * Example of template switch
+     * 
+     * @param mixed $hook_data
+     * @return mixed
+     */
+    public function welcomeBeforeDisplay($hook_data)
+    {
+        error_log('welcome before display hook trigered');
+        return 'copyrights.html';
+    }
+    
+    
+}


### PR DESCRIPTION
Dodano wsparcie dla pluginów.

Działa to tak, że ładowane są pluginy zdefiniowane w uiconfig w zmiennej phpui.plugins. Zmienna ta powinna wyglądać następująco: 
NazwaPluginu:priorytet;NazwaInnegoPluginu:priorytet
Plugin o wskazanej nazwie powinien znajdować się w katalogu plugins, powinna to być klasa o takiej samej nazwie.
Biblioteka oferuje wsparcie dla wielu pluginów ładowanych jednocześnie (można nawet załadować ten sam plugin kilka razy).
Wraz z biblioteką dodano przykładowy plugin, w którym można podejrzeć jak to powinno działać. Zmodyfikowano moduły welcome i useradd dodając w nich zaczepy wywołujace pluginy. Pokazano w jaki sposób można podmienić szablon, rozszerzyć walidację, dodać logowanie zdarzeń. Wraz z wywołaniem pluginów można (ale nie trzeba) przekazać do nich dane które mogą podlec modyfikacji. Dane te są współdzielone pomiędzy pluginami, można to sobie wyobrazić jak potoki gdzie dane na wyjściu jednego pluginu mogą być danymi na wejściu kolejnego. Z tego powodu zapewniono możliwość priorytetowania pluginów. 

Wykorzystano biblioteki phine/lib-observer i phine/lib-exception. Bibioteki te dodano do lib, ale moga one także zostać załadowane przy pomocy composera, ale to kwestia ustalenia czy będziemy w LMS wykorzystywać composera do instalacji zewnętrznych bibliotek.

W przyszłości napiszę bardziej obszerny opis tego mechanizmu i opublikuję tu lub na grupie dyskusyjnej (o ile wejdzie to do LMS).
