### PR TITLE
Fixes example plugin handlers

### DIFF
--- a/plugins/PluginExample/handlers/UseraddHandler.php
+++ b/plugins/PluginExample/handlers/UseraddHandler.php
@@ -42,7 +42,7 @@ class UseraddHandler
         if (strpos($hook_data['useradd']['name'], 'X') !== 0) {
             $hook_data['error']['name'] = 'Name must start with "X" ;-)';
         }
-        return $hook_data['error'];
+        return $hook_data;
     }
     
     /**
@@ -54,7 +54,7 @@ class UseraddHandler
     public function useraddAfterSubmit($hook_data)
     {
         error_log("User with id $hook_data added");
-        return null;
+        return $hook_data;
     }
     
 }

--- a/plugins/PluginExample/handlers/WelcomeHandler.php
+++ b/plugins/PluginExample/handlers/WelcomeHandler.php
@@ -34,12 +34,12 @@ class WelcomeHandler
     /**
      * Example handler that does nothing
      * 
-     * @param type $hook_data
+     * @param mixed $hook_data
      */
     public function welcomeOnLoad($hook_data)
     {
         error_log('welcome on load hook trigered');
-        return null;
+        return $hook_data;
     }
     
     /**


### PR DESCRIPTION
Poprawiono handlery w przykładowym pluginie tak aby możliwe było ich odebranie w module z którego hook został wywołany lub w kolejnym pluginie.
