### PR TITLE
Update lms-cashimport.php

### DIFF
--- a/contrib/bin/lms-cashimport.php
+++ b/contrib/bin/lms-cashimport.php
@@ -94,6 +94,8 @@ if (!$quiet) {
 if (!is_readable($CONFIG_FILE))
 	die("Unable to read configuration file [".$CONFIG_FILE."]!\n");
 
+define('CONFIG_FILE', $CONFIG_FILE);
+
 $CONFIG = (array) parse_ini_file($CONFIG_FILE, true);
 
 // Check for configuration vars and set default values


### PR DESCRIPTION
Zabrakło deklaracji stałej CONFIG, przez co skrypt się sypie na próbie połączenia z bazą.