### PR TITLE
Update LMSDB_driver_postgres.class.php

### DIFF
--- a/lib/LMSDB_driver_postgres.class.php
+++ b/lib/LMSDB_driver_postgres.class.php
@@ -84,7 +84,7 @@ class LMSDB_driver_postgres extends LMSDB_common implements LMSDBDriverInterface
     public function _driver_connect($dbhost, $dbuser, $dbpasswd, $dbname)
     {
         $cstring = join(' ', array(
-            ($dbhost != '' && $dbhost != 'localhost' ? 'host=' . $dbhost : ''),
+            ($dbhost != '' ? 'host=' . $dbhost : ''),
             ($dbuser != '' ? 'user=' . $dbuser : ''),
             ($dbpasswd != '' ? 'password=' . $dbpasswd : ''),
             ($dbname != '' ? 'dbname=' . $dbname : ''),


### PR DESCRIPTION
Miałem problem z połączeniem się z bazą na localhoscie bez tej zmiany, dostawałem wyjątek:

> PHP Driver for postgres database doesn't seems to be loaded.

środowisko testowe: PHP 5.6.6 i PostgreSQL 9.3.6. Ktoś miał podobnie?
W logach widziałem, że zamiast po localhoscie to chciał po gnieździe.