### PR TITLE
fix multiselect customer group in user(add|edit)

### DIFF
--- a/templates/default/user/useradd.html
+++ b/templates/default/user/useradd.html
@@ -137,6 +137,7 @@
 						<INPUT type="checkbox" id="acl_{$access@index}" name="acl[{$name}]" value="1" {if $access.enabled} checked{/if}> <label for="acl_{$access@index}">{$access.name}</label><BR>
 						{/if}
 						{/foreach}
+						{assign var="name" value=""}
 					</td>
 				</tr>
 			</table>

--- a/templates/default/user/usereditbox.html
+++ b/templates/default/user/usereditbox.html
@@ -156,6 +156,7 @@
 						<input type="checkbox" id="acl_{$access@index}" name="acl[{$name}]" value="1"{if $access.enabled} checked{/if}> <label for="acl_{$access@index}">{$access.name}</label><BR>
 						{/if}
 						{/foreach}
+						{assign var="name" value=""}
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
po zmianie accesstable do multiselect.html przekazywana jest zmienna 'name' ( z ostania warością z {foreach $accesslist as $name => $access} ) co powoduje zmianę nazwy i id '<select (..) name="available{$name}[]"  (..) <select (..) name="selected{$name}[]"', 