### PR TITLE
Historia hashy haseł użytkowników

### DIFF
--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -368,6 +368,12 @@ class LMS
         return $manager->getUserRights($id);
     }
 
+    public function PasswdExistsInHistory($id, $passwd) 
+    {
+        $manager = $this->getUserManager();
+        return $manager->PasswdExistsInHistory($id, $passwd);
+    }
+
     /*
      *  Customers functions
      */

--- a/lib/LMSDB_common.class.php
+++ b/lib/LMSDB_common.class.php
@@ -24,7 +24,7 @@
  *  $Id$
  */
 
-define('DBVERSION', '2015122300'); // here should be always the newest version of database!
+define('DBVERSION', '2015122301'); // here should be always the newest version of database!
 				 // it placed here to avoid read disk every time when we call this file.
 
 /**

--- a/lib/LMSManagers/LMSUserManagerInterface.php
+++ b/lib/LMSManagers/LMSUserManagerInterface.php
@@ -54,4 +54,6 @@ interface LMSUserManagerInterface
     public function userUpdate($user);
 
     public function getUserRights($id);
+    
+    public function PasswdExistsInHistory($id, $passwd);
 }

--- a/lib/locale/pl/strings.php
+++ b/lib/locale/pl/strings.php
@@ -3086,4 +3086,6 @@ $_LANG['Building number required!'] = 'Wymagany numer budynku!';
 $_LANG['External system identifier:'] = 'Identyfikator w systemie zewnętrznym:';
 $_LANG['Enter customer identifier in external system (optional)'] = 'Wprowadź identyfikator klienta w systemie zewnętrznym (opcjonalnie)';
 
+$_LANG['You already used this password!'] = 'Takie hasło było już używane!';
+
 ?>

--- a/lib/upgradedb/mysql.2015122301.php
+++ b/lib/upgradedb/mysql.2015122301.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * LMS version 1.11-git
+ *
+ *  (C) Copyright 2001-2015 LMS Developers
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ */
+/**
+ * @author Maciej_Wawryk
+ */
+
+$this->BeginTrans();
+$this->Execute("CREATE TABLE usergroups (
+	id int(11) NOT NULL auto_increment,
+	name varchar(255) DEFAULT '' NOT NULL UNIQUE, 
+	description text DEFAULT '' NOT NULL, 
+	PRIMARY KEY (id));");
+$this->Execute("CREATE TABLE userassignments (
+	id int(11) NOT NULL auto_increment,
+	usergroupid int(11) NOT NULL,
+	userid int(11) NOT NULL,
+	PRIMARY KEY (id),
+	INDEX userassignments_userid_idx (userid),
+	FOREIGN KEY (usergroupid) REFERENCES usergroups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	FOREIGN KEY (userid) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT userassignments_usergroupid_key UNIQUE (usergroupid, userid)
+    );");
+$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2015121800', 'dbversion'));
+$this->CommitTrans();
+
+?>

--- a/lib/upgradedb/mysql.2015122301.php
+++ b/lib/upgradedb/mysql.2015122301.php
@@ -25,22 +25,16 @@
  */
 
 $this->BeginTrans();
-$this->Execute("CREATE TABLE usergroups (
+$this->Execute("
+    CREATE TABLE passwdhistory (
 	id int(11) NOT NULL auto_increment,
-	name varchar(255) DEFAULT '' NOT NULL UNIQUE, 
-	description text DEFAULT '' NOT NULL, 
-	PRIMARY KEY (id));");
-$this->Execute("CREATE TABLE userassignments (
-	id int(11) NOT NULL auto_increment,
-	usergroupid int(11) NOT NULL,
 	userid int(11) NOT NULL,
-	PRIMARY KEY (id),
-	INDEX userassignments_userid_idx (userid),
-	FOREIGN KEY (usergroupid) REFERENCES usergroups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	hash varchar(255) DEFAULT '' NOT NULL,
 	FOREIGN KEY (userid) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
-	CONSTRAINT userassignments_usergroupid_key UNIQUE (usergroupid, userid)
-    );");
-$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2015121800', 'dbversion'));
+	PRIMARY KEY (id),
+");
+$this->Execute("INSERT INTO uiconfig (section, var, value) VALUES(?, ?, ?)", array('phpui', 'passwordhistory', 6));
+$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2015122301', 'dbversion'));
 $this->CommitTrans();
 
 ?>

--- a/lib/upgradedb/postgres.2015122301.php
+++ b/lib/upgradedb/postgres.2015122301.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * LMS version 1.11-git
+ *
+ *  (C) Copyright 2001-2015 LMS Developers
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License Version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ *  USA.
+ *
+ */
+/**
+ * @author Maciej_Wawryk
+ */
+
+$this->BeginTrans();
+
+$this->Execute("
+	CREATE SEQUENCE usergroups_id_seq;
+	CREATE TABLE usergroups (
+		id integer DEFAULT nextval('usergroups_id_seq'::text) NOT NULL,
+		name varchar(255) DEFAULT '' NOT NULL,
+		description text DEFAULT '' NOT NULL,
+		PRIMARY KEY (id),
+		UNIQUE (name)
+	);
+	CREATE SEQUENCE userassignments_id_seq;
+	CREATE TABLE userassignments (
+		id integer DEFAULT nextval('userassignments_id_seq'::text) NOT NULL,
+		usergroupid integer NOT NULL
+			REFERENCES usergroups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		userid integer NOT NULL
+			REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		PRIMARY KEY (id),
+		UNIQUE (usergroupid, userid)
+	);
+	CREATE INDEX userassignments_userid_idx ON userassignments (userid)
+");
+
+$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2015121800', 'dbversion'));
+
+$this->CommitTrans();
+
+?>

--- a/lib/upgradedb/postgres.2015122301.php
+++ b/lib/upgradedb/postgres.2015122301.php
@@ -23,33 +23,19 @@
 /**
  * @author Maciej_Wawryk
  */
-
 $this->BeginTrans();
-
 $this->Execute("
-	CREATE SEQUENCE usergroups_id_seq;
-	CREATE TABLE usergroups (
-		id integer DEFAULT nextval('usergroups_id_seq'::text) NOT NULL,
-		name varchar(255) DEFAULT '' NOT NULL,
-		description text DEFAULT '' NOT NULL,
-		PRIMARY KEY (id),
-		UNIQUE (name)
+	CREATE SEQUENCE passwdhistory_id_seq;
+	CREATE TABLE passwdhistory (
+	    id integer DEFAULT nextval('passwdhistory_id_seq'::text) NOT NULL,
+	    userid integer NOT NULL
+		REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	    hash varchar(255) DEFAULT '' NOT NULL,
+	    PRIMARY KEY (id)
 	);
-	CREATE SEQUENCE userassignments_id_seq;
-	CREATE TABLE userassignments (
-		id integer DEFAULT nextval('userassignments_id_seq'::text) NOT NULL,
-		usergroupid integer NOT NULL
-			REFERENCES usergroups (id) ON DELETE CASCADE ON UPDATE CASCADE,
-		userid integer NOT NULL
-			REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
-		PRIMARY KEY (id),
-		UNIQUE (usergroupid, userid)
-	);
-	CREATE INDEX userassignments_userid_idx ON userassignments (userid)
 ");
-
-$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2015121800', 'dbversion'));
-
+$this->Execute("INSERT INTO uiconfig (section, var, value) VALUES(?, ?, ?)", array('phpui', 'passwordhistory', 6));
+$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2015122301', 'dbversion'));
 $this->CommitTrans();
 
 ?>

--- a/modules/chpasswd.php
+++ b/modules/chpasswd.php
@@ -38,7 +38,9 @@ if ($LMS->UserExists($id))
 			$error['password'] = trans('Passwords does not match!');
 		elseif (!check_password_strength($passwd['passwd']))
 			$error['password'] = trans('The password should contain at least one capital letter, one lower case letter, one digit and should consist of at least 8 characters!');
-
+		elseif ($LMS->PasswdExistsInHistory($id, $passwd['passwd']))
+			$error['password'] = trans('You already used this password!');
+		
 		if (!$error)
 		{
 			$oldpasswd = $LMS->DB->GetOne('SELECT passwd FROM users WHERE id = ?', array($id));

--- a/modules/userpasswd.php
+++ b/modules/userpasswd.php
@@ -38,6 +38,9 @@ if ($LMS->UserExists($id)) {
 
 		if (!check_password_strength($passwd['passwd']))
 			$error['password'] = trans('The password should contain at least one capital letter, one lower case letter, one digit and should consist of at least 8 characters!');
+		
+		if ($LMS->PasswdExistsInHistory($id, $passwd['passwd']))
+			$error['password'] = trans('You already used this password!');
 
 		if (!$error) {
 			$LMS->SetUserPassword($id, $passwd['passwd']);

--- a/modules/users/actions/passwd.php
+++ b/modules/users/actions/passwd.php
@@ -40,6 +40,9 @@ if($LMS->UserExists($id))
 		if($passwd['passwd'] != $passwd['confirm'])
 			$error['password'] = trans('Passwords does not match!');
 		
+		if ($LMS->PasswdExistsInHistory($id, $passwd['passwd']))
+			$error['password'] = trans('You already used this password!');
+		
 		if(!$error)
 		{
 			$LMS->SetUserPassword($id, $passwd['passwd']);


### PR DESCRIPTION
Ma to na celu zwiększenie bezpieczeństwa poprzez zabronienie użytkownikowi używania tego samego hasła podczas jego zmieniania 
ile ostatnich haseł użytkownika porównujemy ustawiamy w interfejsie użytkownika w sekcji phpui opcja passwordhistory, defaultowo ustawiłem 6 ostatnich

Tym razem mam nadzieję, że już dobry pull request :)