### PR TITLE
continue config type

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -28,6 +28,8 @@ version ?.??.?? (????-??-??):
   - replaced all customer selectiors by smarty customerlist function [chilan]
   - removed deprecated chkconfig, check_conf and get_conf public functions [chilan]
   - lib/config.php is needed only for config load module [chilan]
+  - added column with type in uiconfig, and configuration is validated by this type [pjona]
+  - function $LMS->CheckOption() takes a '$type' as the first parameter [pjona]
 
 version 1.11.19 (2015-12-21):
 

--- a/lib/LMSManagers/LMSConfigManager.php
+++ b/lib/LMSManagers/LMSConfigManager.php
@@ -61,17 +61,44 @@ class LMSConfigManager extends LMSManager implements LMSConfigManagerInterface
             case 'phpui.ewx_support':
             case 'phpui.helpdesk_stats':
             case 'phpui.helpdesk_customerinfo':
+            case 'phpui.logging':
+            case 'phpui.note_check_payment':
+            case 'phpui.public_ip':
+            case 'phpui.radius':
+            case 'phpui.hide_summaries':
+            case 'phpui.use_invoices':
+            case 'phpui.hide_toolbar':
+            case 'phpui.default_assignment_invoice':
+            case 'phpui.invoice_check_payment':
+            case 'finances.cashimport_checkinvoices':
+            case 'receipts.show_nodes_warning':
+            case 'invoices.customer_bankaccount':
+            case 'invoices.customer_credentials':
+            case 'invoices.print_balance_history':
                 $type = CONFIG_TYPE_BOOLEAN;
                 break;
 
-            case 'phpui.accountlist_pagelimit':
-            case 'phpui.ticketlist_pagelimit':
+            case 'phpui.customerlist_pagelimit':
+            case 'phpui.nodelist_pagelimit':
             case 'phpui.balancelist_pagelimit':
+            case 'phpui.configlist_pagelimit':
             case 'phpui.invoicelist_pagelimit':
-            case 'phpui.aliaslist_pagelimit':
+            case 'phpui.ticketlist_pagelimit':
+            case 'phpui.accountlist_pagelimit':
             case 'phpui.domainlist_pagelimit':
+            case 'phpui.aliaslist_pagelimit':
+            case 'phpui.receiptlist_pagelimit':
+            case 'phpui.taxratelist_pagelimit':
+            case 'phpui.numberplanlist_pagelimit':
+            case 'phpui.divisionlist_pagelimit':
             case 'phpui.documentlist_pagelimit':
+            case 'phpui.recordlist_pagelimit':
+            case 'phpui.voipaccountlist_pagelimit':
             case 'phpui.networkhosts_pagelimit':
+            case 'phpui.messagelist_pagelimit':
+            case 'phpui.cashreglog_pagelimit':
+            case 'phpui.debitnotelist_pagelimit':
+            case 'phpui.printout_pagelimit':
             case 'phpui.timeout':
             case 'phpui.timetable_days_forward':
             case 'phpui.nodepassword_length':
@@ -80,7 +107,23 @@ class LMSConfigManager extends LMSManager implements LMSConfigManagerInterface
                 break;
 
             case 'mail.debug_email':
+            case 'sendinvoices.debug_email':
+            case 'sendinvoices.sender_email':
+            case 'userpanel.debug_email':
+            case 'zones.hostmaster_mail':
                 $type = CONFIG_TYPE_EMAIL;
+                break;
+
+            case 'phpui.reload_type':
+                $type = CONFIG_TYPE_RELOADTYPE;
+                break;
+
+            case 'notes.type':
+            case 'receipts.type':
+            case 'phpui.report_type':
+            case 'phpui.document_type':
+            case 'invoices.type':
+                $type = CONFIG_TYPE_DOCTYPE;
                 break;
 
             default:
@@ -104,9 +147,14 @@ class LMSConfigManager extends LMSManager implements LMSConfigManagerInterface
                     return trans('Incorrect value! Valid values are: 1|t|true|y|yes|on and 0|n|no|off|false');
                 break;
 
-            case 'reload_type':
+            case CONFIG_TYPE_RELOADTYPE:
                 if ($value != 'sql' && $value != 'exec')
                     return trans('Incorrect reload type. Valid types are: sql, exec!');
+                break;
+
+            case CONFIG_TYPE_DOCTYPE:
+                if ($value != 'html' && $value != 'pdf')
+                    return trans('Incorrect value! Valid values are: html, pdf!');
                 break;
 
             case CONFIG_TYPE_EMAIL:

--- a/lib/definitions.php
+++ b/lib/definitions.php
@@ -80,6 +80,17 @@ define('CONFIG_TYPE_NONE', 0);
 define('CONFIG_TYPE_BOOLEAN', 1);
 define('CONFIG_TYPE_POSITIVE_INTEGER', 2);
 define('CONFIG_TYPE_EMAIL', 3);
+define('CONFIG_TYPE_RELOADTYPE', 4);
+define('CONFIG_TYPE_DOCTYPE', 5);
+
+$CONFIG_TYPES = array(
+	CONFIG_TYPE_NONE => trans('none'),
+	CONFIG_TYPE_BOOLEAN => trans('boolean'),
+	CONFIG_TYPE_POSITIVE_INTEGER => trans('integer greater than 0'),
+	CONFIG_TYPE_EMAIL => trans('email'),
+	CONFIG_TYPE_RELOADTYPE => trans('reload type'),
+	CONFIG_TYPE_DOCTYPE => trans('document type'),
+);
 
 // Helpdesk ticket status
 define('RT_NEW', 0);
@@ -501,6 +512,7 @@ if(isset($SMARTY))
 	$SMARTY->assign('_GUARANTEEPERIODS', $GUARANTEEPERIODS);
 	$SMARTY->assign('_NUM_PERIODS', $NUM_PERIODS);
 	$SMARTY->assign('_RT_STATES', $RT_STATES);
+	$SMARTY->assign('_CONFIG_TYPES', $CONFIG_TYPES);
 	$SMARTY->assign('_MESSENGERS', $MESSENGERS);
 	$SMARTY->assign('_TARIFFTYPES', $TARIFFTYPES);
 	$SMARTY->assign('_PAYTYPES', $PAYTYPES);

--- a/lib/locale/pl/strings.php
+++ b/lib/locale/pl/strings.php
@@ -686,6 +686,7 @@ $_LANG['Incorrect Tax Exempt Number! If you are sure you want to accept it, then
 $_LANG['Incorrect tax rate percentage value (non-zero value and taxing not checked)!'] = 'Nieprawidłowa wartość procentowa podatku (wartość niezerowa i nie zaznaczono opodatkowania)!';
 $_LANG['Incorrect value!'] = 'Błędna wartość!';
 $_LANG['Incorrect value! Valid values are: 1|t|true|y|yes|on and 0|n|no|off|false'] = 'Niepoprawna wartość! Poprawne wartości to: 1|t|true|y|yes|on i 0|n|no|off|false';
+$_LANG['Incorrect value! Valid values are: html, pdf!'] = 'Niepoprawna wartość! Poprawne wartości to: html, pdf!';
 $_LANG['Incorrect WINS server IP address!'] = 'Niepoprawny adres IP serwera WINS!';
 $_LANG['Incorrect ZIP code! If you are sure you want to accept it, then click "Submit" again.'] = 'Niepoprawny kod pocztowy! Jeśli chcesz zaakceptować, to ponownie kliknij "Zapisz".';
 $_LANG['in debt'] = 'zadłużeni';
@@ -3100,5 +3101,8 @@ $_LANG['Check if bank account should be visible on invoice'] = 'Zaznacz, jeśli 
 $_LANG['Check if bank account should be disabled'] = 'Zaznacz, jeśli rachunek bankowy ma być wyłączony';
 $_LANG['Incorrect bank account!'] = 'Niepoprawny numer rachunku bankowego!';
 $_LANG['Bank account is required!'] = 'Rachunek bankowy jest wymagany!';
+
+$_LANG['boolean'] = 'wartość logiczna';
+$_LANG['integer greater than 0'] = 'liczba całkowita większa od 0';
 
 ?>

--- a/modules/configadd.php
+++ b/modules/configadd.php
@@ -53,9 +53,10 @@ if(sizeof($config))
 	elseif (!preg_match('/^[a-z0-9_-]+$/', $section))
 		$error[empty($config['section']) ? 'newsection' : 'section'] = trans('Section name contains forbidden characters!');
 
+	$config['type'] = $LMS->GetConfigDefaultType($config['section'], $config['name']);
 	if($config['value']=='')
 		$error['value'] = trans('Option with empty value not allowed!');
-	elseif($msg = $LMS->CheckOption($config['name'], $config['value']))
+	elseif($msg = $LMS->CheckOption($config['type'], $config['value']))
 	        $error['value'] = $msg;
 	
 	if(!isset($config['disabled'])) $config['disabled'] = 0;
@@ -66,9 +67,10 @@ if(sizeof($config))
 			'name' => $config['name'],
 			'value' => $config['value'],
 			'description' => $config['description'],
-			'disabled' => $config['disabled']
+			'disabled' => $config['disabled'],
+			'type' => $config['type']
 		);
-		$DB->Execute('INSERT INTO uiconfig (section, var, value, description, disabled) VALUES (?, ?, ?, ?, ?)',
+		$DB->Execute('INSERT INTO uiconfig (section, var, value, description, disabled, type) VALUES (?, ?, ?, ?, ?, ?)',
 			array_values($args));
 
 		if ($SYSLOG) {

--- a/modules/configedit.php
+++ b/modules/configedit.php
@@ -50,6 +50,7 @@ if (isset($_GET['statuschange'])) {
 }
 
 $config = $DB->GetRow('SELECT * FROM uiconfig WHERE id = ?', array($id));
+$config['type'] = $config['type'] != 0 ? $config['type'] : $LMS->GetConfigDefaultType($config['section'], $config['var']);
 $option = $config['var'];
 
 if(isset($_POST['config']))
@@ -75,7 +76,6 @@ if(isset($_POST['config']))
 	if(!preg_match('/^[a-z0-9_-]+$/', $cfg['section']) && $cfg['section']!='')
 		$error['section'] = trans('Section name contains forbidden characters!');
 
-	$cfg['type'] = ($cfg['type'] != 0) ? $cfg['type'] : $LMS->GetConfigDefaultType($cfg['section'], $cfg['var']);
 	if($cfg['value']=='')
 		$error['value'] = trans('Empty option value is not allowed!');
 	elseif($msg = $LMS->CheckOption($cfg['type'], $cfg['value']))

--- a/templates/default/config/configedit.html
+++ b/templates/default/config/configedit.html
@@ -63,6 +63,21 @@
 		</TD>
 	</TR>
 	<TR>
+		<TD width="1%">
+			<img src="img/desc.gif" alt="">
+		</TD>
+		<TD width="1%">
+			<B>{trans("Type:")}</B>
+		</TD>
+		<TD width="98%">
+			<SELECT size="1" name="config[type]" {tip text="Select config type" trigger="type"}>
+				{foreach $_CONFIG_TYPES as $key => $type}
+					<OPTION value="{$key}"{if $config.type == $key} selected{/if}>{$type}</OPTION>
+				{/foreach}
+			</SELECT>
+		</TD>
+	</TR>
+	<TR>
 		<TD align="right" colspan="3">
 			<A href="javascript:document.config.submit();" accesskey="s">{trans("Submit")} <img src="img/save.gif" alt=""></A>
 			<A href="?m=configdel&id={$config.id}" OnClick="return confirmLink(this, '{t a=$config.var}Are you sure, you want to delete option \'$a\' from database?{/t}')">{trans("Delete")} <img src="img/delete.gif" alt=""></A>


### PR DESCRIPTION
Dodałem na sztywno kolejne opcje LMS UI gdzie jesteśmy pewni jaki powinien być typ. Dodałem też przy edycji opcji możliwość wyboru z którego typu chcemy skorzystać. Nie jestem tylko do końca pewny czy to dobry pomysł, bo raczej tam gdzie jest `CONFIG_TYPE_BOOLEAN`, `CONFIG_TYPE_POSITIVE_INTEGER`, `CONFIG_TYPE_EMAIL` i pewnie kilka innych, nie powinno się znaleźć nic innego i w tym przypadku nikt nie powinien chyba móc zmienić typ? lub wykorzystywać do tego richtext editora?

Musiałem zmienić interfejs LMSConfigManager, metodę CheckOption() bo stara metoda zakładała że sprawdzamy opcję tylko po `$var` (np. hide_summaries) a u mnie jest już sprawdzanie przez `$section.$var` (np. phpui.hide_summaries), dlatego by i tak musiały się zmienić parametry przekazywane do tej funkcji. Zamiast dodawać 3 parametru `$section`, zmieniłem 1 parametr na `$type` i wg. `$type` jest sprawdzana wartość.

Czekam na sugestie czy się dobrze rozumiemy.