### PR TITLE
Fixed customlinks when using onclick without url

### DIFF
--- a/templates/default/customer/customerbalancebox.html
+++ b/templates/default/customer/customerbalancebox.html
@@ -140,7 +140,8 @@
 					<TD style="width: 92%;">{$item.comment}</TD>
 					<TD style="width: 1%;" class="text-right nobr">
 						{foreach $item.customlinks as $link}
-						<A href="{$link.url}" rel="external"{if isset($link.onclick)} onclick="{$link.onclick}"{/if}>{if isset($link.icon)}<IMG src="{$link.icon}" alt="[ {$link.label} ]" {$link.tip}>{else}{$link.label}{/if}</A>
+						<A {if isset($link.url)} href="{$link.url}" {/if} rel="external" {if isset($link.onclick)} onclick="{$link.onclick}"{/if}>{if isset($link.icon)}<IMG src="{$link.icon}" alt="[ {$link.label} ]" {$link.tip}>{else}{$link.label}{/if}</A>
+						{if isset($link.extra)}{$link.extra}{/if}
 						{/foreach}
 						{if $item.docid}
 							{if $item.doctype == $smarty.const.DOC_INVOICE}


### PR DESCRIPTION
$link.url  - zapobiega otwieraniu nowej karty po kliknięciu w ikonkę
$link.extra - dodałem aby móc dodać jakiś dodatkowy kod html w tym miejscu (np. wyświetlający się fragment kodu uruchamiany przez funkcję onclick)