### PR TITLE
Config type auto and richtext

### DIFF
--- a/lib/LMSManagers/LMSConfigManager.php
+++ b/lib/LMSManagers/LMSConfigManager.php
@@ -140,6 +140,9 @@ class LMSConfigManager extends LMSManager implements LMSConfigManagerInterface
 
     public function CheckOption($option, $value, $type)
     {
+        if($value == '')
+            return trans('Empty option value is not allowed!');
+
         switch ($type) {
             case CONFIG_TYPE_POSITIVE_INTEGER:
                 if ($value <= 0)

--- a/lib/definitions.php
+++ b/lib/definitions.php
@@ -76,15 +76,17 @@ $CSTATUSES = array(
 );
 
 // Config types
-define('CONFIG_TYPE_NONE', 0);
+define('CONFIG_TYPE_AUTO', 0);
 define('CONFIG_TYPE_BOOLEAN', 1);
 define('CONFIG_TYPE_POSITIVE_INTEGER', 2);
 define('CONFIG_TYPE_EMAIL', 3);
 define('CONFIG_TYPE_RELOADTYPE', 4);
 define('CONFIG_TYPE_DOCTYPE', 5);
 define('CONFIG_TYPE_MARGINS', 6);
+define('CONFIG_TYPE_NONE', 7);
 
 $CONFIG_TYPES = array(
+	CONFIG_TYPE_AUTO => trans('- auto -'),
 	CONFIG_TYPE_NONE => trans('none'),
 	CONFIG_TYPE_BOOLEAN => trans('boolean'),
 	CONFIG_TYPE_POSITIVE_INTEGER => trans('integer greater than 0'),

--- a/lib/definitions.php
+++ b/lib/definitions.php
@@ -84,6 +84,7 @@ define('CONFIG_TYPE_RELOADTYPE', 4);
 define('CONFIG_TYPE_DOCTYPE', 5);
 define('CONFIG_TYPE_MARGINS', 6);
 define('CONFIG_TYPE_NONE', 7);
+define('CONFIG_TYPE_RICHTEXT', 8);
 
 $CONFIG_TYPES = array(
 	CONFIG_TYPE_AUTO => trans('- auto -'),
@@ -94,6 +95,7 @@ $CONFIG_TYPES = array(
 	CONFIG_TYPE_RELOADTYPE => trans('reload type'),
 	CONFIG_TYPE_DOCTYPE => trans('document type'),
 	CONFIG_TYPE_MARGINS => trans('margins'),
+	CONFIG_TYPE_RICHTEXT => trans('visual editor'),
 );
 
 // Helpdesk ticket status

--- a/lib/locale/lt/strings.php
+++ b/lib/locale/lt/strings.php
@@ -1003,7 +1003,6 @@ $_LANG['Option exists!'] = 'Pasirinktis jau egzistuoja!';
 $_LANG['Option name contains forbidden characters!'] = 'Pasirinkties pavadinime yra neleistinų ženklų.';
 $_LANG['Option name is required!'] = 'Reikia pasirinkties pavadinimo!';
 $_LANG['Option name is too long (max.64 characters)!'] = 'Reikia pasirinkties pavadinimo (maks. 64 ženklai)!';
-$_LANG['Option with empty value not allowed!'] = 'Pasirinkties vertė negali būti tuščia!';
 $_LANG['Option with specified name exists in that instance!'] = 'Tokio pavadinimo pasirinktis jau yra šiame atvejyje!';
 $_LANG['OR'] = 'ARBA';
 $_LANG['or Customer ID:'] = 'arba kliento ID:';

--- a/lib/locale/pl/strings.php
+++ b/lib/locale/pl/strings.php
@@ -1004,7 +1004,6 @@ $_LANG['Option exists!'] = 'Opcja juz istnieje!';
 $_LANG['Option name contains forbidden characters!'] = 'Nazwa opcji zawiera niedozwolone znaki.';
 $_LANG['Option name is required!'] = 'Nazwa opcji jest wymagana!';
 $_LANG['Option name is too long (max.64 characters)!'] = 'Nazwa opcji jest wymagana (maks 64 znaki)!';
-$_LANG['Option with empty value not allowed!'] = 'Opcja z pustą wartością nie jest dozwolona!';
 $_LANG['Option with specified name exists in that instance!'] = 'Opcja o podanej nazwie istnieje w tej instancji!';
 $_LANG['OR'] = 'LUB';
 $_LANG['or Customer ID:'] = 'lub ID klienta:';

--- a/lib/locale/ro/strings.php
+++ b/lib/locale/ro/strings.php
@@ -973,7 +973,6 @@ $_LANG['Option exists!'] = 'Opţiunea există!';
 $_LANG['Option name contains forbidden characters!'] = 'Nume opţiune conţine niedozwolone caractere.';
 $_LANG['Option name is required!'] = 'Nume opţiune este obligatoriu de completat!';
 $_LANG['Option name is too long (max.64 characters)!'] = 'Nume opţiune este obligatoriu de completat (maks 64 caractere)!';
-$_LANG['Option with empty value not allowed!'] = 'Opţiunea cu valoare goală nu e permisă!';
 $_LANG['Option with specified name exists in that instance!'] = 'Opţiunea o podanej nume istnieje w tej instancji!';
 $_LANG['OR'] = 'SAU';
 $_LANG['or Customer ID:'] = 'sau identificator client:';

--- a/lib/locale/sk/strings.php
+++ b/lib/locale/sk/strings.php
@@ -1002,7 +1002,6 @@ $_LANG['Option exists!'] = 'Voľba už existuje!';
 $_LANG['Option name contains forbidden characters!'] = 'Meno voľby obsahuje zakázané znaky.';
 $_LANG['Option name is required!'] = 'Meno voľby je povinné!';
 $_LANG['Option name is too long (max.64 characters)!'] = 'Meno voľby je príliš dlhé (max. 64 znakov)!';
-$_LANG['Option with empty value not allowed!'] = 'Voľba s prázdnou hodnotou nieje povolená!';
 $_LANG['Option with specified name exists in that instance!'] = 'Voľba s daným menom v danej inštancií už existuje!';
 $_LANG['OR'] = 'ALEBO';
 $_LANG['or Customer ID:'] = 'alebo ID zákazníka:';

--- a/modules/configadd.php
+++ b/modules/configadd.php
@@ -54,7 +54,10 @@ if(sizeof($config))
 		$error[empty($config['section']) ? 'newsection' : 'section'] = trans('Section name contains forbidden characters!');
 
 	$option = $config['section'] . '.' . $config['var'];
-	$config['type'] = $LMS->GetConfigDefaultType($option);
+
+	if(!ConfigHelper::checkPrivilege('superuser') || $config['type'] == CONFIG_TYPE_AUTO)
+		$config['type'] = $LMS->GetConfigDefaultType($option);
+
 	if($config['value']=='')
 		$error['value'] = trans('Option with empty value not allowed!');
 	elseif($msg = $LMS->CheckOption($option, $config['value'], $config['type']))

--- a/modules/configadd.php
+++ b/modules/configadd.php
@@ -54,13 +54,10 @@ if(sizeof($config))
 		$error[empty($config['section']) ? 'newsection' : 'section'] = trans('Section name contains forbidden characters!');
 
 	$option = $config['section'] . '.' . $config['var'];
-
 	if(!ConfigHelper::checkPrivilege('superuser') || $config['type'] == CONFIG_TYPE_AUTO)
 		$config['type'] = $LMS->GetConfigDefaultType($option);
 
-	if($config['value']=='')
-		$error['value'] = trans('Option with empty value not allowed!');
-	elseif($msg = $LMS->CheckOption($option, $config['value'], $config['type']))
+	if($msg = $LMS->CheckOption($option, $config['value'], $config['type']))
 		$error['value'] = $msg;
 	
 	if(!isset($config['disabled'])) $config['disabled'] = 0;

--- a/modules/configedit.php
+++ b/modules/configedit.php
@@ -51,7 +51,7 @@ if (isset($_GET['statuschange'])) {
 
 $config = $DB->GetRow('SELECT * FROM uiconfig WHERE id = ?', array($id));
 $option = $config['section'] . '.' . $config['var'];
-$config['type'] = ($config['type'] != 0) ? $config['type'] : $LMS->GetConfigDefaultType($option);
+$config['type'] = ($config['type'] == CONFIG_TYPE_AUTO) ? $LMS->GetConfigDefaultType($option) : $config['type'];
 
 if(isset($_POST['config']))
 {
@@ -60,7 +60,7 @@ if(isset($_POST['config']))
 
 	if(!ConfigHelper::checkPrivilege('superuser'))
 		$cfg['type'] = $config['type'];
-	
+
 	foreach($cfg as $key => $val) 
 		$cfg[$key] = trim($val);
 	

--- a/modules/configedit.php
+++ b/modules/configedit.php
@@ -58,12 +58,12 @@ if(isset($_POST['config']))
 	$cfg = $_POST['config'];
 	$cfg['id'] = $id;
 
+	foreach($cfg as $key => $val)
+		$cfg[$key] = trim($val);
+
 	if(!ConfigHelper::checkPrivilege('superuser'))
 		$cfg['type'] = $config['type'];
 
-	foreach($cfg as $key => $val) 
-		$cfg[$key] = trim($val);
-	
 	if($cfg['var']=='')
 		$error['var'] = trans('Option name is required!');
 	elseif(strlen($cfg['var'])>64)
@@ -79,9 +79,11 @@ if(isset($_POST['config']))
 	if(!preg_match('/^[a-z0-9_-]+$/', $cfg['section']) && $cfg['section']!='')
 		$error['section'] = trans('Section name contains forbidden characters!');
 
-	if($cfg['value']=='')
-		$error['value'] = trans('Empty option value is not allowed!');
-	elseif($msg = $LMS->CheckOption($cfg['section'] . '.' . $cfg['var'], $cfg['value'], $cfg['type']))
+	$option = $cfg['section'] . '.' . $cfg['var'];
+	if($cfg['type'] == CONFIG_TYPE_AUTO)
+		$cfg['type'] = $LMS->GetConfigDefaultType($option);
+
+	if($msg = $LMS->CheckOption($option, $cfg['value'], $cfg['type']))
 		$error['value'] = $msg;
 
 	if(!isset($cfg['disabled'])) $cfg['disabled'] = 0;

--- a/modules/configedit.php
+++ b/modules/configedit.php
@@ -83,10 +83,13 @@ if(isset($_POST['config']))
 		$error['value'] = trans('Empty option value is not allowed!');
 	elseif($msg = $LMS->CheckOption($cfg['section'] . '.' . $cfg['var'], $cfg['value'], $cfg['type']))
 		$error['value'] = $msg;
-	
+
 	if(!isset($cfg['disabled'])) $cfg['disabled'] = 0;
 
 	if (!$error) {
+		if(isset($_POST['richtext']))
+			$cfg['type'] = CONFIG_TYPE_RICHTEXT;
+
 		$args = array(
 			'section' => $cfg['section'],
 			'var' => $cfg['var'],

--- a/templates/default/config/configadd.html
+++ b/templates/default/config/configadd.html
@@ -69,6 +69,23 @@
 			<INPUT type="checkbox" value="1" name="config[disabled]" id="config_disabled"{if $config.disabled} CHECKED{/if} {tip text="You can turn it off"}><label for="config_disabled">{trans("Off")}</label>
 		</TD>
 	</TR>
+	{if ConfigHelper::checkPrivilege('superuser')}
+	<TR>
+		<TD width="1%">
+			<img src="img/desc.gif" alt="">
+		</TD>
+		<TD width="1%">
+			<B>{trans("Type:")}</B>
+		</TD>
+		<TD width="98%">
+			<SELECT size="1" name="config[type]" {tip text="Select config type" trigger="type"}>
+				{foreach $_CONFIG_TYPES as $key => $type}
+					<OPTION value="{$key}"{if $config.type == $key} selected{/if}>{$type}</OPTION>
+				{/foreach}
+			</SELECT>
+		</TD>
+	</TR>
+	{/if}
 	<TR>
 		<TD align="right" colspan="3">
 			<A href="javascript:document.config.submit();" accesskey="s">{trans("Submit")} <img src="img/save.gif" alt=""></A>

--- a/templates/default/config/configedit.html
+++ b/templates/default/config/configedit.html
@@ -35,7 +35,7 @@
 			<B>{trans("Value:")}</B>
 		</TD>
 		<TD width="98%">
-			<input type="checkbox" id="value_label" onclick="javascript:toggle_visual_editor('value');">
+			<input type="checkbox" name="richtext" id="value_label" onclick="javascript:toggle_visual_editor('value');"{if $config.type == $smarty.const.CONFIG_TYPE_RICHTEXT} checked="checked"{/if}>
 			<label for="value_label">{trans("visual editor")}</label><br>
 			<TEXTAREA rows="5" cols="50" name="config[value]" id="value" {tip text="Enter option value" trigger="value"}>{$config.value}</TEXTAREA>
 		</TD>
@@ -94,6 +94,10 @@
 	document.forms['config'].elements['config[var]'].focus();
 
 	tinymce_init('{$_ui_language}');
+
+	{if $config.type == $smarty.const.CONFIG_TYPE_RICHTEXT}
+		toggle_visual_editor('value');
+	{/if}
 //-->
 </SCRIPT>
 {/block}


### PR DESCRIPTION
- dodałem możliwość ustawienia typu przez admina przy dodawaniu nowej opcji
- dodałem typ `auto`, który jest defaultowo, jeśli automatycznie nie rozpoznamy opcji to zwracany jest typ `none`
- dodałem obsługę `richtext`
- pozbyłem się jednego tłumaczenia bo w zasadzie znaczyły to samo:
 - "Option with empty value not allowed!"
 - "Empty option value is not allowed!"


Można pomyśleć nad kolejnymi typami:
- `CONFIG_TYPE_TEXT` - wszystko dozwolone? 
- `CONFIG_TYPE_WORD` - jedno słowo bez spacji (`^[A-Za-z0-9]$`)
- `CONFIG_TYPE_WORD_LIST` - lista słów oddzielonymi spacjami (póki co chyba tylko przy phpui.plugins się przyda?)