### PR TITLE
problem dwukropka w polu opisu przelwu

### DIFF
--- a/contrib/bin/lms-cashimport-bgz-soap.php
+++ b/contrib/bin/lms-cashimport-bgz-soap.php
@@ -105,7 +105,13 @@ function mt940Parser($file){
 			$dwukropek=stripos($line,':');
 			if ( ($dwukropek==0)&&($dwukropek!==false) ){
 				$pole=preg_split('/:/',$line);
-				$wplaty_parser[$i][$pole[1]]=trim($pole[2]);
+                                if (isset($pole[4])){
+                                        $wplaty_parser[$i][$pole[1]]=trim($pole[2]).':'.trim($pole[3]).':'.trim($pole[4]);
+                                }elseif(isset($pole[3])){
+                                        $wplaty_parser[$i][$pole[1]]=trim($pole[2]).':'.trim($pole[3]);
+                                }else{
+					$wplaty_parser[$i][$pole[1]]=trim($pole[2]);
+                                }
 				switch ($pole[1]) {
    				case '61':
    					$wplaty_parser[$i]['value']=str_replace(",", ".", trim(substr($pole[2],11,strpos($pole[2],'NOTREF')-11)));


### PR DESCRIPTION
jesli jest dwukropek w polu opisu przelewu to byl opis byl ucinany do pierwszego dwuropka