### PR TITLE
change input type from text to email for emails [html5]

### DIFF
--- a/templates/default/account/accountadd.html
+++ b/templates/default/account/accountadd.html
@@ -131,7 +131,7 @@
 					<B>{trans("Forward e-mail:")}</B>
 				    </TD>
 				    <TD width="98%">
-					<input type="text" name="account[mail_forward]" size="25" value="{$account.mail_forward}" {tip text="Enter destination e-mail address for redirect (optional)" trigger="mail_forward"}>
+					<input type="email" name="account[mail_forward]" size="25" value="{$account.mail_forward}" {tip text="Enter destination e-mail address for redirect (optional)" trigger="mail_forward"}>
 				    </TD>
 				</TR>
 				<TR>
@@ -142,7 +142,7 @@
 					<B>{trans("BCC e-mail:")}</B>
 				    </TD>
 				    <TD width="98%">
-					<input type="text" name="account[mail_bcc]" size="25" value="{$account.mail_bcc}" {tip text="Enter e-mail address for blind carbon copy (optional)" trigger="mail_bcc"}>
+					<input type="email" name="account[mail_bcc]" size="25" value="{$account.mail_bcc}" {tip text="Enter e-mail address for blind carbon copy (optional)" trigger="mail_bcc"}>
 				    </TD>
 				</TR>
 			    </TABLE>

--- a/templates/default/account/accountedit.html
+++ b/templates/default/account/accountedit.html
@@ -109,7 +109,7 @@
 					<B>{trans("Forward e-mail:")}</B>
 				    </TD>
 				    <TD width="98%">
-					<input type="text" name="account[mail_forward]" size="25" value="{$account.mail_forward}" {tip text="Enter destination e-mail address for redirect (optional)" trigger="mail_forward"}>
+					<input type="email" name="account[mail_forward]" size="25" value="{$account.mail_forward}" {tip text="Enter destination e-mail address for redirect (optional)" trigger="mail_forward"}>
 				    </TD>
 				</TR>
 				<TR>
@@ -120,7 +120,7 @@
 					<B>{trans("BCC e-mail:")}</B>
 				    </TD>
 				    <TD width="98%">
-					<input type="text" name="account[mail_bcc]" size="25" value="{$account.mail_bcc}" {tip text="Enter e-mail address for blind carbon copy (optional)" trigger="mail_bcc"}>
+					<input type="email" name="account[mail_bcc]" size="25" value="{$account.mail_bcc}" {tip text="Enter e-mail address for blind carbon copy (optional)" trigger="mail_bcc"}>
 				    </TD>
 				</TR>
 			    </TABLE>

--- a/templates/default/customer/customeradd.html
+++ b/templates/default/customer/customeradd.html
@@ -389,7 +389,7 @@
 								<TR id="email{$key}">
 									<TD class="nobr">
 										{if !$item@first}<HR>{/if}
-										<INPUT type="text" size="23" value="{$item.email}" name="customeradd[emails][{$key}][email]" {tip text="Enter e-mail address (optional)" trigger="email`$key`"}>
+										<INPUT type="email" size="23" value="{$item.email}" name="customeradd[emails][{$key}][email]" {tip text="Enter e-mail address (optional)" trigger="email`$key`"}>
 										<label {tip text="Check if sent electronic invoices on this email"}>
 											<INPUT TYPE="checkbox" value="{$smarty.const.CONTACT_INVOICES}" name="customeradd[emails][{$key}][type][]"{if ($item.type & $smarty.const.CONTACT_INVOICES)} checked{/if}>
 											{$_CONTACTTYPES[$smarty.const.CONTACT_INVOICES]}

--- a/templates/default/customer/customereditbox.html
+++ b/templates/default/customer/customereditbox.html
@@ -373,7 +373,7 @@
 					<TR id="email{$key}">
 						<TD>
 							{if !$item@first}<HR>{/if}
-							<INPUT type="text" size="23" value="{$item.email}" name="customerdata[emails][{$key}][email]" {tip text="Enter e-mail address (optional)" trigger="email`$key`"}>
+							<INPUT type="email" size="23" value="{$item.email}" name="customerdata[emails][{$key}][email]" {tip text="Enter e-mail address (optional)" trigger="email`$key`"}>
 							<label {tip text="Check if sent electronic invoices on this email"}>
 								<INPUT TYPE="checkbox" value="{$smarty.const.CONTACT_INVOICES}" name="customerdata[emails][{$key}][type][]"{if ($item.type & $smarty.const.CONTACT_INVOICES)} checked{/if}>
 								{$_CONTACTTYPES[$smarty.const.CONTACT_INVOICES]}

--- a/templates/default/customer/customersearch.html
+++ b/templates/default/customer/customersearch.html
@@ -100,7 +100,7 @@
 			<IMG src="img/mail.gif" alt=""> {trans("E-mail:")}
 		</TD>
 		<TD style="width: 99%;">
-			<INPUT type="text" name="search[email]" VALUE="{$search.email}">
+			<INPUT type="email" name="search[email]" VALUE="{$search.email}">
 		</TD>
 	</TR>
 	{*

--- a/templates/default/message/messageadd.html
+++ b/templates/default/message/messageadd.html
@@ -293,7 +293,7 @@
 			{trans("Sender E-mail:")}
 		</TD>
 		<TD style="width: 98%;">
-			<INPUT type="text" name="message[sender]" size="40" value="{if $message.sender}{$message.sender}{elseif $userinfo.email}{$userinfo.email}{/if}" {tip trigger="sender" text="Enter sender e-mail address"}>
+			<INPUT type="email" name="message[sender]" size="40" value="{if $message.sender}{$message.sender}{elseif $userinfo.email}{$userinfo.email}{/if}" {tip trigger="sender" text="Enter sender e-mail address"}>
 			<label {tip trigger="copytosender" text="Check if you want do send message copy to sender"}>
 			<input type="checkbox" name="message[copytosender]"{if ConfigHelper::checkConfig('phpui.send_message_to_sender_checkbox')} checked{/if}>
 			{trans("send copy to sender")}</label>

--- a/templates/default/record/recordedit.html
+++ b/templates/default/record/recordedit.html
@@ -102,7 +102,7 @@
 	<TR id="email" style="display: none">
                 <TD width="1%"><IMG src="img/mail.gif" alt=""></TD>
 	        <TD width="1%" nowrap>{trans("E-mail address:")}</TD>
-		<TD width="98%"><input type="text" value="{$record.email|escape}" name="record[email]" size="40" {tip text="Enter e-mail address" trigger="email"}></TD>
+		<TD width="98%"><input type="email" value="{$record.email|escape}" name="record[email]" size="40" {tip text="Enter e-mail address" trigger="email"}></TD>
 	</TD>
 	<TR id="serial" style="display: none">
                 <TD width="1%"><IMG src="img/serialnumber.gif" alt=""></TD>

--- a/templates/default/rt/rtqueueadd.html
+++ b/templates/default/rt/rtqueueadd.html
@@ -36,7 +36,7 @@
 								</TD>
 								<TD style="width: 1%;" class="bold">{trans("E-mail")}:</TD>
 								<TD style="width: 98%;">
-									<INPUT TYPE="TEXT" SIZE="50" NAME="queue[email]" VALUE="{$queue.email}" {tip text="Enter e-mail address" trigger="email"}>
+									<INPUT TYPE="email" SIZE="50" NAME="queue[email]" VALUE="{$queue.email}" {tip text="Enter e-mail address" trigger="email"}>
 								</TD>
 							</TR>
 							<TR>

--- a/templates/default/rt/rtqueueedit.html
+++ b/templates/default/rt/rtqueueedit.html
@@ -36,7 +36,7 @@
 								</TD>
 								<TD style="width: 1%;" class="bold">{trans("E-mail:")}</TD>
 								<TD style="width: 98%;">
-									<INPUT TYPE="TEXT" SIZE="50" NAME="queue[email]" VALUE="{$queue.email}" {tip text="Enter e-mail address" trigger="email"}>
+									<INPUT TYPE="email" SIZE="50" NAME="queue[email]" VALUE="{$queue.email}" {tip text="Enter e-mail address" trigger="email"}>
 								</TD>
 							</TR>
 							<TR>

--- a/templates/default/rt/rtsearch.html
+++ b/templates/default/rt/rtsearch.html
@@ -48,7 +48,7 @@
 			    </TR>
 			    <TR>
 				<TD width="1%">{trans("E-mail:")}</TD>
-				<TD width="99%"><INPUT type="text" name="search[email]" value="{$search.email}" {tip text="Select customer from list or enter his data if is not a customer"}></TD>
+				<TD width="99%"><INPUT type="email" name="search[email]" value="{$search.email}" {tip text="Select customer from list or enter his data if is not a customer"}></TD>
 			    </TR>
 			</TABLE>
 		</TD>

--- a/templates/default/user/useradd.html
+++ b/templates/default/user/useradd.html
@@ -41,7 +41,7 @@
 			<IMG src="img/mail.gif" alt=""> {trans("E-mail:")}
 		</TD>
 		<TD>
-			<INPUT type="text" name="useradd[email]" value="{$useradd.email}" size="40" {tip text="Enter e-mail address (optional)" trigger="email"}>
+			<INPUT type="email" name="useradd[email]" value="{$useradd.email}" size="40" {tip text="Enter e-mail address (optional)" trigger="email"}>
 		</TD>
 	</TR>
 	<TR>

--- a/templates/default/user/usereditbox.html
+++ b/templates/default/user/usereditbox.html
@@ -43,7 +43,7 @@
 		</TD>
 		<TD class="bold">{trans("E-mail:")}</TD>
 		<TD>
-			<INPUT type="text" name="userinfo[email]" value="{$userinfo.email}" size="40" {tip text="Enter e-mail address (optional)" trigger="email"}>
+			<INPUT type="email" name="userinfo[email]" value="{$userinfo.email}" size="40" {tip text="Enter e-mail address (optional)" trigger="email"}>
 		</TD>
 	</TR>
 	<TR>


### PR DESCRIPTION
Natywna walidacja adresów email, jeśli przeglądarka obsługuje typ "email" dla inputa.