### PR TITLE
Fix layout block name

### DIFF
--- a/templates/default/layout.html
+++ b/templates/default/layout.html
@@ -8,7 +8,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset={$LANGDEFS.$_ui_language.charset}">
         <link href="{ConfigHelper::getConfig('phpui.style', 'img/style.css')}" rel="stylesheet" type="text/css">
         <link href="img/map.css" rel="stylesheet" type="text/css">
-        {block name="extra-css-styles"}{/block}
+        {block name="extra_css_styles"}{/block}
         <link href="img/lms-net.gif" rel="shortcut icon">
         <script type="text/javascript" src="img/common.js"></script>
         <script type="text/javascript" src="img/ClickShowHideMenu.js"></script>


### PR DESCRIPTION
Nie działa dziedziczenie w szablonach smarty, jeśli blok ma w nazwie hyphen "-"