### PR TITLE
Improve translation - balance on invoice

### DIFF
--- a/lib/LMSDocuments/LMSTcpdfInvoice.php
+++ b/lib/LMSDocuments/LMSTcpdfInvoice.php
@@ -698,7 +698,7 @@ class LMSTcpdfInvoice extends LMSInvoice {
 		global $LMS;
 
 		$this->backend->SetFont('arial', '', 7);
-		$this->backend->writeHTMLCell(0, 0, '', '', trans('Your balance on date of invoice issue:') . ' ' . moneyf($LMS->GetCustomerBalance($this->data['customerid'], $this->data['cdate'])), 0, 1, 0, true, 'L');
+		$this->backend->writeHTMLCell(0, 0, '', '', trans('Your balance before invoice issue:') . ' ' . moneyf($LMS->GetCustomerBalance($this->data['customerid'], $this->data['cdate'])), 0, 1, 0, true, 'L');
 	}
 
 	protected function invoice_dates() {

--- a/lib/locale/pl/strings.php
+++ b/lib/locale/pl/strings.php
@@ -2752,7 +2752,7 @@ $_LANG['Connect to device'] = 'Podłączenie do urządzenia';
 $_LANG['Previous operation has not been finished yet!'] = 'Poprzednia czynność nie została jeszcze zakończona!';
 $_LANG['You haven\\\'t selected any nodes!'] = 'Nie wybrałeś żadnego komputera!';
 
-$_LANG['Your balance on date of invoice issue:'] = 'Saldo w dniu wystawienia faktury:';
+$_LANG['Your balance before invoice issue:'] = 'Saldo przed wystawieniem faktury:';
 
 $_LANG['Remove management URL'] = 'Usuń adres URL do zarządzania';
 $_LANG['Edit management URL'] = 'Edytuj adres URL do zarządzania';


### PR DESCRIPTION
Bardziej jednoznaczne tłumaczenie. Obecne _"w dniu wystawienia faktury"_ może wprowadzać w błąd, bo nie wiadomo czy chodzi o saldo przed czy po wystawieniu faktury.