### PR TITLE
separate promotion schemas and group promotion names

### DIFF
--- a/modules/customerassignmentadd.php
+++ b/modules/customerassignmentadd.php
@@ -318,7 +318,6 @@ $customernodes = $LMS->GetCustomerNodes($customer['id']);
 unset($customernodes['total']);
 
 $schemas_only_names = $DB->GetAll('SELECT name FROM promotions WHERE disabled <> 1');
-
 $schemas = $DB->GetAll('SELECT p.name AS promotion, s.name, s.id,
 	(SELECT '.$DB->GroupConcat('tariffid', ',').'
 		FROM promotionassignments WHERE promotionschemaid = s.id

--- a/modules/customerassignmentadd.php
+++ b/modules/customerassignmentadd.php
@@ -339,7 +339,7 @@ $LMS->executeHook(
 
 $SMARTY->assign('assignment', $a);
 $SMARTY->assign('customernodes', $customernodes);
-$SMARTY->assign('promotionschemasnames', $schemas_only_names);
+$SMARTY->assign('promotionschemanames', $schemas_only_names);
 $SMARTY->assign('promotionschemas', $schemas);
 $SMARTY->assign('tariffs', $LMS->GetTariffs());
 $SMARTY->assign('taxeslist', $LMS->GetTaxes());

--- a/modules/customerassignmentadd.php
+++ b/modules/customerassignmentadd.php
@@ -317,6 +317,8 @@ $SESSION->save('backto', $_SERVER['QUERY_STRING']);
 $customernodes = $LMS->GetCustomerNodes($customer['id']);
 unset($customernodes['total']);
 
+$schemas_only_names = $DB->GetAll('SELECT name FROM promotions WHERE disabled <> 1');
+
 $schemas = $DB->GetAll('SELECT p.name AS promotion, s.name, s.id,
 	(SELECT '.$DB->GroupConcat('tariffid', ',').'
 		FROM promotionassignments WHERE promotionschemaid = s.id
@@ -338,6 +340,7 @@ $LMS->executeHook(
 
 $SMARTY->assign('assignment', $a);
 $SMARTY->assign('customernodes', $customernodes);
+$SMARTY->assign('promotionschemasnames', $schemas_only_names);
 $SMARTY->assign('promotionschemas', $schemas);
 $SMARTY->assign('tariffs', $LMS->GetTariffs());
 $SMARTY->assign('taxeslist', $LMS->GetTaxes());

--- a/templates/default/customer/customerassignmentsedit.html
+++ b/templates/default/customer/customerassignmentsedit.html
@@ -131,10 +131,10 @@
 		</TD>
 		<TD style="width: 98%;">
 			<SELECT size="1" name="assignment[schemaid]" {tip text="Select promotion schema"} onchange="set_schema()">
-				{foreach from=$promotionschemasnames item=schemaname}
+				{foreach $promotionschemanames as $schemaname}
                                     <optgroup label="{$schemaname.name}">
-                                        {foreach from=$promotionschemas item=schema}
-                                            {if $schemaname.name eq $schema.promotion}
+                                        {foreach $promotionschemas as $schema}
+                                            {if $schemaname.name == $schema.promotion}
                                                 <OPTION value="{$schema.id}"{if $assignment.schemaid == $schema.id} SELECTED{/if}>{$schema.name|truncate:40:"...":true}</OPTION>
                                             {/if}
                                         {/foreach}

--- a/templates/default/customer/customerassignmentsedit.html
+++ b/templates/default/customer/customerassignmentsedit.html
@@ -94,9 +94,15 @@
 		</TD>
 		<TD style="width: 98%;">
 			<SELECT size="1" name="assignment[schemaid]" {tip text="Select promotion schema"} onchange="set_schema()">
-				{foreach from=$promotionschemas item=schema}
-				<OPTION value="{$schema.id}"{if $assignment.schemaid == $schema.id} SELECTED{/if}>{$schema.promotion|truncate:40:"...":true} / {$schema.name|truncate:40:"...":true}</OPTION>
-				{/foreach}
+				{foreach from=$promotionschemasnames item=schemaname}
+                                    <optgroup label="{$schemaname.name}">
+                                        {foreach from=$promotionschemas item=schema}
+                                            {if $schemaname.name eq $schema.promotion}
+                                                <OPTION value="{$schema.id}"{if $assignment.schemaid == $schema.id} SELECTED{/if}>{$schema.name|truncate:40:"...":true}</OPTION>
+                                            {/if}
+                                        {/foreach}
+                                    </optgroup>
+                                {/foreach}
 			</SELECT>
 		</TD>
 	</TR>


### PR DESCRIPTION
Użyłem **[optgroup](https://www.w3.org/TR/WCAG20-TECHS/H85.html)**

@chilek oceni jak się pull prezentuje od strony programistycznej, bo pewnie można to lepiej zapisać :)