### PR TITLE
Optimize the order of styles and scripts

### DIFF
--- a/templates/default/header.html
+++ b/templates/default/header.html
@@ -6,10 +6,10 @@
     <meta name="GENERATOR" content="LMS {$layout.lmsv}">
     <meta http-equiv="Content-Language" content="{$LANGDEFS.$_ui_language.html}">
     <meta http-equiv="Content-Type" content="text/html; charset={$LANGDEFS.$_ui_language.charset}">
-	{include file="jquery.html" language=$LANGDEFS.$_ui_language.html}
     <link href="{ConfigHelper::getConfig('phpui.style', 'img/style.css')}" rel="stylesheet" type="text/css">
     <link href="img/map.css" rel="stylesheet" type="text/css">
     <link href="img/lms-net.gif" rel="shortcut icon">
+	{include file="jquery.html" language=$LANGDEFS.$_ui_language.html}
     <script type="text/javascript" src="img/common.js"> </script>
     <script type="text/javascript" src="img/ClickShowHideMenu.js"> </script>
     <script type="text/javascript" src="img/autosuggest.js"> </script>

--- a/templates/default/layout-without-footer.html
+++ b/templates/default/layout-without-footer.html
@@ -6,10 +6,10 @@
         <meta name="GENERATOR" content="LMS {$layout.lmsv}">
         <meta http-equiv="Content-Language" content="{$LANGDEFS.$_ui_language.html}">
         <meta http-equiv="Content-Type" content="text/html; charset={$LANGDEFS.$_ui_language.charset}">
-		{include file="jquery.html" language=$LANGDEFS.$_ui_language.html}
         <link href="{ConfigHelper::getConfig('phpui.style', 'img/style.css')}" rel="stylesheet" type="text/css">
         <link href="img/map.css" rel="stylesheet" type="text/css">
         <link href="img/lms-net.gif" rel="shortcut icon">
+		{include file="jquery.html" language=$LANGDEFS.$_ui_language.html}
         <script type="text/javascript" src="img/common.js"></script>
         <script type="text/javascript" src="img/ClickShowHideMenu.js"></script>
         <script type="text/javascript" src="img/autosuggest.js"></script>

--- a/templates/default/layout.html
+++ b/templates/default/layout.html
@@ -6,11 +6,11 @@
         <meta name="GENERATOR" content="LMS {$layout.lmsv}">
         <meta http-equiv="Content-Language" content="{$LANGDEFS.$_ui_language.html}">
         <meta http-equiv="Content-Type" content="text/html; charset={$LANGDEFS.$_ui_language.charset}">
-		{include file="jquery.html" language=$LANGDEFS.$_ui_language.html}
         <link href="{ConfigHelper::getConfig('phpui.style', 'img/style.css')}" rel="stylesheet" type="text/css">
         <link href="img/map.css" rel="stylesheet" type="text/css">
         {block name="extra-css-styles"}{/block}
         <link href="img/lms-net.gif" rel="shortcut icon">
+		{include file="jquery.html" language=$LANGDEFS.$_ui_language.html}
         <script type="text/javascript" src="img/common.js"></script>
         <script type="text/javascript" src="img/ClickShowHideMenu.js"></script>
         <script type="text/javascript" src="img/autosuggest.js"></script>


### PR DESCRIPTION
The following external CSS files were included after an external JavaScript file in the document head. To ensure CSS files are downloaded in parallel, always include external CSS before external JavaScript.

1. style.css
2. map.css