### PR TITLE
[BCLEAN] add class text-color for class bg-primary

### DIFF
--- a/userpanel/modules/finances/style/bclean/templates/userassignments.html
+++ b/userpanel/modules/finances/style/bclean/templates/userassignments.html
@@ -3,7 +3,7 @@
 {$count = 0}
 <div class="table-responsive">
 <table class="table table-bordered table-striped">
-    <tr class="bg-primary">
+    <tr class="bg-primary text-white">
         <th>{trans("Tariff")}</th>
 	<th>{trans("Subscription")}</th>
         <th>{trans("Discount:")}</th>

--- a/userpanel/modules/finances/style/bclean/templates/userassignments.html
+++ b/userpanel/modules/finances/style/bclean/templates/userassignments.html
@@ -40,7 +40,7 @@
     </tr>
     {/foreach}
 	{if $count > 1}
-    <tr class="bg-primary">
+    <tr class="bg-primary text-white">
 	<td>{trans("Total:")}</td>
 	<td>{sum array=$assignments column="real_value" string_format=$LANGDEFS.$_language.money_format}</td>
 	<td>({sum array=$assignments column="real_disc_value" string_format=$LANGDEFS.$_language.money_format})</td>

--- a/userpanel/modules/finances/style/bclean/templates/userbalancebox.html
+++ b/userpanel/modules/finances/style/bclean/templates/userbalancebox.html
@@ -5,7 +5,7 @@
         <form name="invoices" action="?m=finances&amp;f=invoice" method="POST" target="_blank">
 	    <div class="table-responsive">
             <table class="table table-bordered table-hover">
-                <tr class="bg-primary">
+                <tr class="bg-primary text-white">
                     <th>{trans("Date")}</th>
                     <th>Zobowiązanie</th>
                     <th>Wpłata</th>

--- a/userpanel/modules/helpdesk/style/bclean/templates/helpdesklist.html
+++ b/userpanel/modules/helpdesk/style/bclean/templates/helpdesklist.html
@@ -1,7 +1,7 @@
 {box title="Request history"}
 <div class="table-responsive">
 <table class="table table-bordered table-hover">
-    <tr class="bg-primary">
+    <tr class="bg-primary text-white">
         <th>{trans("Number:")}</th>
         <th>{trans("Date:")}</th>
         <th>{trans("Subject:")}</th>

--- a/userpanel/modules/info/style/bclean/templates/userdocsbox.html
+++ b/userpanel/modules/info/style/bclean/templates/userdocsbox.html
@@ -2,7 +2,7 @@
 <div class="table-responsive">
 	<table class="table table-bordered table-hover">
 		{if $documents}
-			<tr class="bg-primary">
+			<tr class="bg-primary text-white">
 				<th>{trans("Number:")}</th>
 				<th>{trans("Type:")}</th>
 				<th>{trans("Created:")}</th>

--- a/userpanel/modules/info/style/bclean/templates/userinfobox.html
+++ b/userpanel/modules/info/style/bclean/templates/userinfobox.html
@@ -2,7 +2,7 @@
 {if $fields_changed}<div class="alert alert-danger">{trans("WARNING! Some fields have been changed and changes must become accepted by admin")}.</div>{/if}
 <div class="table-responsive">
 <table class="table table-bordered table-hover">
-    <tr class="bg-primary">
+    <tr class="bg-primary text-white">
         <th colspan="2">Dane osobowe:</th>
     </tr>
     <tr>

--- a/userpanel/modules/info/style/bclean/templates/usernodesbox.html
+++ b/userpanel/modules/info/style/bclean/templates/usernodesbox.html
@@ -1,7 +1,7 @@
 {box title="Your computers"}
 <div class="table-responsive">
 <table class="table table-hover table-bordered">
-    <tr class="bg-primary">
+    <tr class="bg-primary text-white">
         <th>Opis urządzenia:</th>
         <th>MAC adres</th>
         <th>Publiczne IP:</th>

--- a/userpanel/modules/notices/style/bclean/templates/notices.html
+++ b/userpanel/modules/notices/style/bclean/templates/notices.html
@@ -45,7 +45,7 @@
 {if $notice}
 <div class="table-responsive">
 <table class="table table-bordered">
-    <tr class="bg-primary">
+    <tr class="bg-primary text-white">
         <th>{trans("Date:")}</th>
         <th>{trans("Status:")}</th>
         <th>{trans("Subject:")}</th>


### PR DESCRIPTION
Background utilities do not set color, so in some cases you’ll want to use .text-* utilities.
Changes emerged from the version from v4.0.0-alpha.5