### PR TITLE
BCLEAN-VOIP: fix JS warning - when customer dont have voip account

### DIFF
--- a/userpanel/modules/voip/style/bclean/templates/billing.html
+++ b/userpanel/modules/voip/style/bclean/templates/billing.html
@@ -175,6 +175,7 @@
 		{/if}
 	</DIV>
 </div>
+{if $user_accounts}
 <script>
     $( function() {
 	    $('[data-toggle="tooltip"]').tooltip();
@@ -276,4 +277,5 @@
         }
     } );
 </script>
+{/if}
 {include file="footer.html"}


### PR DESCRIPTION
Łatka dla https://github.com/chilek/lms-plus/issues/294 punkt 1