### PR TITLE
bugfix: set custom headers when using phpmailer backend to send emails

### DIFF
--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -1946,6 +1946,12 @@ class LMS
 			foreach (explode(",", $recipients) as $recipient)
 				$this->mail_object->addAddress($recipient);
 
+			foreach ($headers as $name => $value) {
+				if (strpos(strtolower($name), 'x') === 0) {
+					$this->mail_object->addCustomHeader($name, $value);
+				}
+			}
+
 			// setup your cert & key file
 			$cert = LIB_DIR . DIRECTORY_SEPARATOR . 'lms-mail.cert';
 			$key = LIB_DIR . DIRECTORY_SEPARATOR . 'lms.key';


### PR DESCRIPTION
W przypadku użycia backendu phpmailer brakowało ustawiania customowych nagłówków.