### PR TITLE
Update postgres.2017101202.php

### DIFF
--- a/lib/upgradedb/postgres.2017101202.php
+++ b/lib/upgradedb/postgres.2017101202.php
@@ -95,7 +95,8 @@ $this->Execute("
 	ALTER TABLE ewx_pt_config ALTER COLUMN nodeid SET DEFAULT NULL;
 	ALTER TABLE messageitems ALTER COLUMN messageid DROP DEFAULT;
 	ALTER TABLE up_help ALTER COLUMN reference DROP NOT NULL;
-	ALTER TABLE up_help ALTER COLUMN reference SET DEFAULT NULL
+	ALTER TABLE up_help ALTER COLUMN reference SET DEFAULT NULL;
+	UPDATE up_help SET reference = NULL WHERE reference = 0
 ");
 
 $this->Execute("UPDATE customers SET divisionid = NULL WHERE divisionid = 0");


### PR DESCRIPTION
bez tej zmiany może nie nie dodać się to ograniczenie z postgres.2017101203.php
	ALTER TABLE up_help ADD CONSTRAINT up_help_reference_fkey
		FOREIGN KEY (reference) REFERENCES up_help (id) ON DELETE CASCADE ON UPDATE CASCADE;

SQL pisałem z palca, może być błędne