### PR TITLE
Update invoice.php

### DIFF
--- a/modules/invoice.php
+++ b/modules/invoice.php
@@ -278,7 +278,7 @@ if (isset($_GET['print']) && $_GET['print'] == 'cached') {
 					$ten = str_replace('-', '', $invoice['ten']);
 					if (preg_match('/^[A-Z]{2}[0-9]+$/', $ten))
 						$ue = true;
-					elseif (!preg_match('/^[0-9]{10}$/', $ten))
+					elseif (preg_match('/^[0-9]{10}$/', $ten))
 						$foreign = true;
 				}
 


### PR DESCRIPTION
Generowanie jpk dla osób zwolnionych z kraju nie posiadających numeru nip zwracało błędny plik jpk. 
Pozostawienie u klienta pustego numeru nip powodowało że był traktowany jako obcy i wpadał w k_11 i k_12