### PR TITLE
 improvement: cannot close ticket from rtnote and rtmessageadd when phpui.helpdesk_block_ticket_close_with_open_events is enabled

### DIFF
--- a/modules/rtnoteadd.php
+++ b/modules/rtnoteadd.php
@@ -97,7 +97,6 @@ elseif(isset($_POST['note']))
 			'verifierid' => empty($note['verifierid']) ? null : $note['verifierid'],
 			'deadline' => $note['deadline'],
 		);
-
 		$LMS->TicketChange($note['ticketid'], $props);
 
 		if(isset($note['notify']))

--- a/modules/rtnoteadd.php
+++ b/modules/rtnoteadd.php
@@ -47,7 +47,12 @@ if(isset($_GET['ticketid']))
 elseif(isset($_POST['note']))
 {
 	$note = $_POST['note'];
-	$ticket = $DB->GetRow('SELECT id AS ticketid, state, cause, queueid, owner, address_id FROM rttickets WHERE id = ?', array($note['ticketid']));
+	$ticket = $LMS->GetTicketContents($note['ticketid']);
+
+        if (ConfigHelper::checkConfig('phpui.helpdesk_block_ticket_close_with_open_events')) {
+            if($ticket['state'] == RT_RESOLVED && !empty($ticket['openeventscount']))
+                $error['state'] = trans('Ticket have open assigned events!');
+        }
 
 	if($note['body'] == '')
 		$error['body'] = trans('Note body not specified!');
@@ -92,6 +97,7 @@ elseif(isset($_POST['note']))
 			'verifierid' => empty($note['verifierid']) ? null : $note['verifierid'],
 			'deadline' => $note['deadline'],
 		);
+
 		$LMS->TicketChange($note['ticketid'], $props);
 
 		if(isset($note['notify']))

--- a/templates/default/rt/rtnoteadd.html
+++ b/templates/default/rt/rtnoteadd.html
@@ -69,10 +69,9 @@
 		</TD>
 		<TD>
 			<SELECT SIZE="1" name="note[state]" {tip text="Select status" trigger="state"}>
-				<OPTION value="{$smarty.const.RT_NEW}" {if $note.state == $smarty.const.RT_NEW}SELECTED{/if}>{trans("new")}</OPTION>
-				<OPTION value="{$smarty.const.RT_OPEN}" {if $note.state == $smarty.const.RT_OPEN}SELECTED{/if}>{trans("opened")}</OPTION>
-				<OPTION value="{$smarty.const.RT_RESOLVED}" {if $note.state == $smarty.const.RT_RESOLVED}SELECTED{/if}>{trans("resolved")}</OPTION>
-				<OPTION value="{$smarty.const.RT_DEAD}" {if $note.state == $smarty.const.RT_DEAD}SELECTED{/if}>{trans("dead")}</OPTION>
+                        {foreach $_RT_STATES as $stateidx => $state}
+                                <OPTION value="{$stateidx}"{if $note.states == $stateidx} selected{/if}>{$state.label}</OPTION>
+                        {/foreach}
 			</SELECT>
 		</TD>
 	</TR>


### PR DESCRIPTION
Nie mogę namierzyć problemu dlaczego to nie działa tak jak oczekuję. Nie wyświetla się warning.