### PR TITLE
Added rt.mail_file_umask variable

### DIFF
--- a/lib/LMSManagers/LMSHelpdeskManager.php
+++ b/lib/LMSManagers/LMSHelpdeskManager.php
@@ -710,7 +710,7 @@ class LMSHelpdeskManager extends LMSManager implements LMSHelpdeskManagerInterfa
 
 	private function SaveTicketMessageAttachments($ticketid, $messageid, $files, $cleanup = false) {
 		if (!empty($files) && ($dir = ConfigHelper::getConfig('rt.mail_dir'))) {
-			@umask(0007);
+			@umask(intval(ConfigHelper::getConfig('rt.mail_file_umask', '0007'), 8));
 			$dir_permission = intval(ConfigHelper::getConfig('rt.mail_dir_permission', '0700'), 8);
 			$dir = $dir . DIRECTORY_SEPARATOR . sprintf('%06d', $ticketid);
 			@mkdir($dir, $dir_permission);


### PR DESCRIPTION
This is to give us some more control over the default privileges for mail attachments, similarly to what `rt.mail_dir_permissions` does for the directory structure.

My use case is that the rtparser runs as an lms user, so an example attachement would look like this

```
268024     24 -rw-rw----   1 lms      lms         21735 Sep 12 12:25  000035/000106/test.png
```
This of course prevents the apache user from reading the files.

Now, once `rt.mail_file_umask` is set to 0022 the attachments are created as follows.
```
268023     24 -rw-r--r--   1 lms      lms         21735 Sep 12 11:53  000036/000107/test.png
```

I am adding this as a variable as I understand that it may work for everyone.
