### PR TITLE
Fixed the endless Re: Re: loop

### DIFF
--- a/modules/rtmessageadd.php
+++ b/modules/rtmessageadd.php
@@ -375,7 +375,11 @@ else
 				$message['destination'] = implode(',', $message['destination']);
 		}
 
-		$message['subject'] = 'Re: '.$reply['subject'];
+		if (preg_match('#^Re: #i', $reply['subject']) === 1) {
+			$message['subject'] = $reply['subject'];
+		} else {
+			$message['subject'] = 'Re: '. $reply['subject'];	
+		}
 		$message['inreplyto'] = $reply['id'];
 		$message['references'] = implode(' ', $reply['references']);
 


### PR DESCRIPTION
Currently when responding to messages via helpdesk the 'Re:' is appended by the following piece of code

```
$message['subject'] = 'Re: '.$reply['subject'];
```

However, it the message has been exchanged between client and helpdesk a number of times the subject line would contain Re: multiple times - i.e. 'Re: Re: Re: test'