### PR TITLE
Improvement: Update to ensure that %tid in notifications is also in 6 digit format

### DIFF
--- a/bin/lms-rtparser.php
+++ b/bin/lms-rtparser.php
@@ -540,11 +540,12 @@ if ($notify) {
 			$ticketbody_variable = 'newmessagebody';
 		}
 		if (!empty($queuedata[$ticketsubject_variable]) && !empty($queuedata[$ticketbody_variable]) && !empty($emails)) {
+			$ticketid = sprintf("%06d", $ticket_id);
 			$custmail_subject = $queuedata[$ticketsubject_variable];
-			$custmail_subject = str_replace('%tid', $ticket_id, $custmail_subject);
+			$custmail_subject = str_replace('%tid', $ticketid, $custmail_subject);
 			$custmail_subject = str_replace('%title', $mh_subject, $custmail_subject);
 			$custmail_body = $queuedata[$ticketbody_variable];
-			$custmail_body = str_replace('%tid', $ticket_id, $custmail_body);
+			$custmail_body = str_replace('%tid', $ticketid, $custmail_body);
 			$custmail_body = str_replace('%cid', $ticket['customerid'], $custmail_body);
 			$custmail_body = str_replace('%pin', $info['pin'], $custmail_body);
 			$custmail_body = str_replace('%customername', $info['customername'], $custmail_body);

--- a/bin/lms-sms2rt.php
+++ b/bin/lms-sms2rt.php
@@ -276,11 +276,12 @@ if (($fh = fopen($message_file, "r")) != NULL) {
 			}
 
 			if (!empty($queuedata['newticketsubject']) && !empty($queuedata['newticketbody']) && !empty($emails)) {
+				$ticketid = sprintf("%06d", $ticket_id);
 				$custmail_subject = $queuedata['newticketsubject'];
-				$custmail_subject = str_replace('%tid', $ticket_id, $custmail_subject);
+				$custmail_subject = str_replace('%tid', $ticketid, $custmail_subject);
 				$custmail_subject = str_replace('%title', $mh_subject, $custmail_subject);
 				$custmail_body = $queuedata['newticketbody'];
-				$custmail_body = str_replace('%tid', $ticket_id, $custmail_body);
+				$custmail_body = str_replace('%tid', $ticketid, $custmail_body);
 				$custmail_body = str_replace('%cid', $ticket['customerid'], $custmail_body);
 				$custmail_body = str_replace('%pin', $info['pin'], $custmail_body);
 				$custmail_body = str_replace('%customername', $info['customername'], $custmail_body);

--- a/modules/rtmessageadd.php
+++ b/modules/rtmessageadd.php
@@ -275,13 +275,14 @@ if(isset($_POST['message']))
 				$queuedata = $LMS->GetQueueByTicketId($message['ticketid']);
 				if (isset($message['customernotify']) && !empty($queuedata['newmessagesubject']) && !empty($queuedata['newmessagebody'])
 					&& !empty($emails)) {
+					$ticketid = sprintf("%06d", $id);
 					$title = $DB->GetOne('SELECT subject FROM rtmessages WHERE ticketid = ?
 						ORDER BY id LIMIT 1', array($message['ticketid']));
 					$custmail_subject = $queuedata['newmessagesubject'];
-					$custmail_subject = str_replace('%tid', $id, $custmail_subject);
+					$custmail_subject = str_replace('%tid', $ticketid, $custmail_subject);
 					$custmail_subject = str_replace('%title', $title, $custmail_subject);
 					$custmail_body = $queuedata['newmessagebody'];
-					$custmail_body = str_replace('%tid', $id, $custmail_body);
+					$custmail_body = str_replace('%tid', $ticketid, $custmail_body);
 					$custmail_body = str_replace('%cid', $ticketdata['customerid'], $custmail_body);
 					$custmail_body = str_replace('%pin', $info['pin'], $custmail_body);
 					$custmail_body = str_replace('%customername', $info['customername'], $custmail_body);

--- a/modules/rtticketadd.php
+++ b/modules/rtticketadd.php
@@ -212,11 +212,12 @@ if(isset($_POST['ticket']))
 
 				if (isset($ticket['customernotify']) && !empty($queuedata['newticketsubject']) && !empty($queuedata['newticketbody'])
 					&& !empty($emails)) {
+					$ticketid = sprintf("%06d", $id);
 					$custmail_subject = $queuedata['newticketsubject'];
-					$custmail_subject = str_replace('%tid', $id, $custmail_subject);
+					$custmail_subject = str_replace('%tid', $ticketid, $custmail_subject);
 					$custmail_subject = str_replace('%title', $ticket['subject'], $custmail_subject);
 					$custmail_body = $queuedata['newticketbody'];
-					$custmail_body = str_replace('%tid', $id, $custmail_body);
+					$custmail_body = str_replace('%tid', $ticketid, $custmail_body);
 					$custmail_body = str_replace('%cid', $ticket['customerid'], $custmail_body);
 					$custmail_body = str_replace('%pin', $info['pin'], $custmail_body);
 					$custmail_body = str_replace('%customername', $info['customername'], $custmail_body);

--- a/modules/rtticketedit.php
+++ b/modules/rtticketedit.php
@@ -76,11 +76,12 @@ if ($id && !isset($_POST['ticket'])) {
 			if (!empty($queue['resolveticketsubject']) && !empty($queue['resolveticketbody'])) {
 				if (!empty($ticket['customerid'])) {
 					if (!empty($emails)) {
+						$ticketid = sprintf("%06d", $id);
 						$custmail_subject = $queue['resolveticketsubject'];
-						$custmail_subject = str_replace('%tid', $id, $custmail_subject);
+						$custmail_subject = str_replace('%tid', $ticketid, $custmail_subject);
 						$custmail_subject = str_replace('%title', $ticket['subject'], $custmail_subject);
 						$custmail_body = $queue['resolveticketbody'];
-						$custmail_body = str_replace('%tid', $id, $custmail_body);
+						$custmail_body = str_replace('%tid', $ticketid, $custmail_body);
 						$custmail_body = str_replace('%cid', $info['id'], $custmail_body);
 						$custmail_body = str_replace('%pin', $info['pin'], $custmail_body);
 						$custmail_body = str_replace('%customername', $info['customername'], $custmail_body);

--- a/userpanel/modules/helpdesk/functions.php
+++ b/userpanel/modules/helpdesk/functions.php
@@ -215,11 +215,12 @@ function module_main() {
 				$queuedata = $LMS->GetQueue($ticket['queue']);
 				if (!empty($queuedata['newticketsubject']) && !empty($queuedata['newticketbody'])
 					&& !empty($emails)) {
+					$ticketid = sprintf("%06d", $id);
 					$custmail_subject = $queuedata['newticketsubject'];
-					$custmail_subject = str_replace('%tid', $id, $custmail_subject);
+					$custmail_subject = str_replace('%tid', $ticketid, $custmail_subject);
 					$custmail_subject = str_replace('%title', $ticket['subject'], $custmail_subject);
 					$custmail_body = $queuedata['newticketbody'];
-					$custmail_body = str_replace('%tid', $id, $custmail_body);
+					$custmail_body = str_replace('%tid', $ticketid, $custmail_body);
 					$custmail_body = str_replace('%cid', $SESSION->id, $custmail_body);
 					$custmail_body = str_replace('%pin', $info['pin'], $custmail_body);
 					$custmail_body = str_replace('%customername', $info['customername'], $custmail_body);


### PR DESCRIPTION
This is to fix the - and I don't want to call it a bug - where the `%tid` in helpdesk notifications is essentially an `$id` - ie. `42`, whereas the replies to messages are `sprintf('%06d', $id)`, so `000042`. This PR changes the behaviour so that the long (i.e. `000042`) format is used.