### PR TITLE
Fix: Re: should be added after the helpdesk_notification_mail_subject…

### DIFF
--- a/bin/lms-rtparser.php
+++ b/bin/lms-rtparser.php
@@ -577,6 +577,8 @@ if ($notify) {
 		'url' => $lms_url,
 	);
 	$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+	if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+		$headers['Subject'] = 'Re: '.$headers['Subject'];
 	$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 	$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 	$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;

--- a/bin/lms-sms2rt.php
+++ b/bin/lms-sms2rt.php
@@ -313,6 +313,8 @@ if (($fh = fopen($message_file, "r")) != NULL) {
 			'url' => $lms_url . '?m=rtticketview&id=',
 		);
 		$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+		if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+			$headers['Subject'] = 'Re: '.$headers['Subject'];
 		$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 		$message = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 		$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;

--- a/modules/rtmessageadd.php
+++ b/modules/rtmessageadd.php
@@ -316,6 +316,8 @@ if(isset($_POST['message']))
 			);
 			$headers['X-Priority'] = $RT_MAIL_PRIORITIES[$ticketdata['priority']];
 			$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+			if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+				$headers['Subject'] = 'Re: '.$headers['Subject'];
 			$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 			$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 			$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;

--- a/modules/rtnoteadd.php
+++ b/modules/rtnoteadd.php
@@ -179,6 +179,8 @@ elseif(isset($_POST['note']))
 				$params['subject'] = 'Re: '.$ticketdata['subject'];
 
 			$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+			if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+				$headers['Subject'] = 'Re: '.$headers['Subject'];
 			$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 			$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 			$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;

--- a/modules/rtticketadd.php
+++ b/modules/rtticketadd.php
@@ -254,6 +254,8 @@ if(isset($_POST['ticket']))
 			);
 			$headers['X-Priority'] = $RT_MAIL_PRIORITIES[$ticketdata['priority']];
 			$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+			if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+				$headers['Subject'] = 'Re: '.$headers['Subject'];
 			$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 			$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 			$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;

--- a/modules/rtticketedit.php
+++ b/modules/rtticketedit.php
@@ -139,6 +139,8 @@ if ($id && !isset($_POST['ticket'])) {
 				'body' => $message['body'],
 			);
 			$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+			if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+				$headers['Subject'] = 'Re: '.$headers['Subject'];
 			$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 			$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 			$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;
@@ -356,6 +358,8 @@ if(isset($_POST['ticket']))
 				'body' => $message['body'],
 			);
 			$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+			if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+				$headers['Subject'] = 'Re: '.$headers['Subject'];
 			$params['customerinfo'] =  isset($mail_customerinfo) ? $mail_customerinfo : null;
 			$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 			$params['customerinfo'] =  isset($sms_customerinfo) ? $sms_customerinfo : null;

--- a/userpanel/modules/helpdesk/functions.php
+++ b/userpanel/modules/helpdesk/functions.php
@@ -250,6 +250,8 @@ function module_main() {
 					$params['url'] = $lms_url;
 
 				$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+				if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+					$headers['Subject'] = 'Re: '.$headers['Subject'];
 				$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 				$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 				$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;
@@ -398,6 +400,8 @@ function module_main() {
 				$params['url'] = $lms_url;
 
 			$headers['Subject'] = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_subject'), $params);
+			if(ConfigHelper::checkConfig('rt.helpdesk_notification_prefix_re'))
+				$headers['Subject'] = 'Re: '.$headers['Subject'];
 			$params['customerinfo'] = isset($mail_customerinfo) ? $mail_customerinfo : null;
 			$body = $LMS->ReplaceNotificationSymbols(ConfigHelper::getConfig('phpui.helpdesk_notification_mail_body'), $params);
 			$params['customerinfo'] = isset($sms_customerinfo) ? $sms_customerinfo : null;


### PR DESCRIPTION
Currently `rt.note_send_re_in_subject` appends `Re:` before the `ReplaceNotificationSymbols`, so this results in an email subject of a `[RT#123456] Re: subject`.

This PR changes the behaviour so that the `Re:` is appended after the `ReplaceNotificationSymbols`, and the resulting subject is `Re: [RT#123456] subject` or whatever else the `phpui.helpdesk_notification_mail_subject` dictates.
