### PR TITLE
Enhancement: Add support for phpui.helpdesk_sender_email

### DIFF
--- a/modules/eventadd.php
+++ b/modules/eventadd.php
@@ -154,12 +154,22 @@ if(isset($_POST['event']))
 				else
 					$mailfname = '';
 
-				if ($user['email'])
-					$mailfrom = $user['email'];
-				elseif ($qemail = $LMS->GetQueueEmail($ticket['queue']))
-					$mailfrom = $qemail;
-				else
-					$mailfrom =  $ticket['mailfrom'];
+				$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+				if(!empty($helpdesk_sender_email)) {
+					$mailfrom = $helpdesk_sender_email;
+
+					if($mailfrom == 'queue')
+						$mailfrom = $LMS->GetQueueEmail($ticket['queue']);
+					elseif($mailfrom == 'user')
+						$mailfrom = $user['email'];
+				} else {
+					if ($user['email'])
+						$mailfrom = $user['email'];
+					elseif ($qemail = $LMS->GetQueueEmail($ticket['queue']))
+						$mailfrom = $qemail;
+					else
+						$mailfrom =  $ticket['mailfrom'];
+				}
 
 				$ticketdata = $LMS->GetTicketContents($event['ticketid']);
 

--- a/modules/rtmessageadd.php
+++ b/modules/rtmessageadd.php
@@ -102,8 +102,18 @@ if(isset($_POST['message']))
 				&& $message['destination'] != $queue['email'])
 			{
 				$recipients = $message['destination'];
-				$message['mailfrom'] = $user['email'] ? $user['email'] : $queue['email'];
+				$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+				if(!empty($helpdesk_sender_email)) {
+					$mailfrom = $helpdesk_sender_email;
 
+					if($mailfrom == 'queue')
+						$mailfrom = $queue['email'];
+					elseif($mailfrom == 'user')
+						$mailfrom = $user['email'];
+				} else {
+					$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+				}
+				$message['mailfrom'] = $mailfrom;
 				$headers['Date'] = date('r');
 				$headers['From'] = $mailfname.' <'.$message['mailfrom'].'>';
 				$headers['To'] = '<'.$message['destination'].'>';
@@ -147,10 +157,21 @@ if(isset($_POST['message']))
 				$message['destination'] = $queue['email'];
 			$recipients = $message['destination'];
 
-			if($message['userid'] && $addmsg)
-				$message['mailfrom'] = $queue['email'] ? $queue['email'] : $user['email'];
-			if($message['userid'] && !$addmsg)
-				$message['mailfrom'] = $user['email'] ? $user['email'] : $queue['email'];
+			$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+			if(!empty($helpdesk_sender_email)) {
+				$mailfrom = $helpdesk_sender_email;
+
+				if($mailfrom == 'queue')
+					$mailfrom = $queue['email'];
+				elseif($mailfrom == 'user')
+					$mailfrom = $user['email'];
+			} else {
+				if($message['userid'] && $addmsg)
+					$mailfrom = $queue['email'] ? $queue['email'] : $user['email'];
+				if($message['userid'] && !$addmsg)
+					$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			}
+			$message['mailfrom'] = $mailfrom;
 
 			if($message['customerid']) {
 				$message['mailfrom'] = $LMS->GetCustomerEmail($message['customerid']);
@@ -243,7 +264,17 @@ if(isset($_POST['message']))
 				$mailfname = '"'.$mailfname.'"';
 			}
 
-			$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+			if(!empty($helpdesk_sender_email)) {
+				$mailfrom = $helpdesk_sender_email;
+
+				if($mailfrom == 'queue')
+					$mailfrom = $queue['email'];
+				elseif($mailfrom == 'user')
+					$mailfrom = $user['email'];
+			} else {
+				$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			}
 
 			$ticketdata = $LMS->GetTicketContents($message['ticketid']);
 

--- a/modules/rtnoteadd.php
+++ b/modules/rtnoteadd.php
@@ -123,7 +123,17 @@ elseif(isset($_POST['note']))
 				$mailfname = '"'.$mailfname.'"';
 			}
 
-			$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+			if(!empty($helpdesk_sender_email)) {
+				$mailfrom = $helpdesk_sender_email;
+
+				if($mailfrom == 'queue')
+					$mailfrom = $queue['email'];
+				elseif($mailfrom == 'user')
+					$mailfrom = $user['email'];
+			} else {
+				$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			}
 
 			$ticketdata = $LMS->GetTicketContents($note['ticketid']);
 

--- a/modules/rtticketadd.php
+++ b/modules/rtticketadd.php
@@ -171,12 +171,21 @@ if(isset($_POST['ticket']))
 			else
 				$mailfname = '';
 
-			if ($user['email'])
-				$mailfrom = $user['email'];
-			elseif ($qemail = $LMS->GetQueueEmail($queue))
-				$mailfrom = $qemail;
-			else
-				$mailfrom =  $ticket['mailfrom'];
+			$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+			if(!empty($helpdesk_sender_email)) {
+				$mailfrom = $helpdesk_sender_email;
+				if($mailfrom == 'queue')
+					$mailfrom = $LMS->GetQueueEmail($queue);
+				elseif($mailfrom == 'user')
+					$mailfrom = $user['email'];
+			} else {
+				if ($user['email'])
+					$mailfrom = $user['email'];
+				elseif ($qemail = $LMS->GetQueueEmail($queue))
+					$mailfrom = $qemail;
+				else
+					$mailfrom =  $ticket['mailfrom'];
+			}
 
 			$ticketdata = $LMS->GetTicketContents($id);
 

--- a/modules/rtticketedit.php
+++ b/modules/rtticketedit.php
@@ -69,7 +69,17 @@ if ($id && !isset($_POST['ticket'])) {
 			$mailfname = '"' . $mailfname . '"';
 		}
 
-		$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+		$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+		if(!empty($helpdesk_sender_email)) {
+			$mailfrom = $helpdesk_sender_email;
+
+			if($mailfrom == 'queue')
+				$mailfrom = $queue['email'];
+			elseif($mailfrom == 'user')
+				$mailfrom = $user['email'];
+		} else {
+			$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+		}
 		$from = $mailfname . ' <' . $mailfrom . '>';
 
 		if ($state == RT_RESOLVED) {
@@ -305,7 +315,17 @@ if(isset($_POST['ticket']))
 				$mailfname = '"' . $mailfname . '"';
 			}
 
-			$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+			if(!empty($helpdesk_sender_email)) {
+				$mailfrom = $helpdesk_sender_email;
+
+				if($mailfrom == 'queue')
+					$mailfrom = $queue['email'];
+				elseif($mailfrom == 'user')
+					$mailfrom = $user['email'];
+			} else {
+				$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
+			}
 
 			$ticketdata = $LMS->GetTicketContents($ticket['ticketid']);
 

--- a/userpanel/modules/helpdesk/functions.php
+++ b/userpanel/modules/helpdesk/functions.php
@@ -177,12 +177,22 @@ function module_main() {
 					$mailfname = '"'.$mailfname.'"';
 				}
 
-				if ($user['email'])
-					$mailfrom = $user['email'];
-				elseif ($qemail = $LMS->GetQueueEmail($ticket['queue']))
-					$mailfrom = $qemail;
-				else
-					$mailfrom =  $ticket['mailfrom'];
+				$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+				if(!empty($helpdesk_sender_email)) {
+					$mailfrom = $helpdesk_sender_email;
+
+					if($mailfrom == 'queue')
+						$mailfrom = $LMS->GetQueueEmail($ticket['queue']);
+					elseif($mailfrom == 'user')
+						$mailfrom = $user['email'];
+				} else {
+					if ($user['email'])
+						$mailfrom = $user['email'];
+					elseif ($qemail = $LMS->GetQueueEmail($ticket['queue']))
+						$mailfrom = $qemail;
+					else
+						$mailfrom =  $ticket['mailfrom'];
+				}
 
 				$ticketdata = $LMS->GetTicketContents($id);
 
@@ -342,12 +352,22 @@ function module_main() {
 			$ticket['email'] = $LMS->GetCustomerEmail($SESSION->id);
 			$ticket['mailfrom'] = $ticket['email'] ? $ticket['email'] : '';
 
-			if ($user['email'])
-				$mailfrom = $user['email'];
-			elseif (!empty($ticket['queue']['email']))
-				$mailfrom = $ticket['queue']['email'];
-			else
-				$mailfrom = $ticket['mailfrom'];
+			$helpdesk_sender_email = ConfigHelper::getConfig('phpui.helpdesk_sender_email');
+			if(!empty($helpdesk_sender_email)) {
+				$mailfrom = $helpdesk_sender_email;
+
+				if($mailfrom == 'queue')
+					$mailfrom = $ticket['queue']['email'];
+				elseif($mailfrom == 'user')
+					$mailfrom = $user['email'];
+			} else {
+				if ($user['email'])
+					$mailfrom = $user['email'];
+				elseif (!empty($ticket['queue']['email']))
+					$mailfrom = $ticket['queue']['email'];
+				else
+					$mailfrom = $ticket['mailfrom'];
+			}
 
 			$ticketdata = $LMS->GetTicketContents($ticket['id']);
 


### PR DESCRIPTION
Currently a variable `phpui.helpdesk_sender_name` exists that controls the name of of the sender.

However it does not alter the sender's email address, which in case of notifications is expanded as follows
```
$mailfrom = $user['email'] ? $user['email'] : $queue['email'];
```

My understanding is that if the user has a specified email address in LMS, that will be used by default. 
Now, removing email addresses of users is impractical as this would mean they wouldn't be receiving any LMS notifications. 

This PR adds support for forcing the FROM address to be be either:
- queue
- user
- custom