### PR TITLE
[userpanel/blcean] cleanups with JS

### DIFF
--- a/userpanel/style/bclean/composer.json
+++ b/userpanel/style/bclean/composer.json
@@ -12,8 +12,7 @@
         "email": "lukasz@alfa-system.pl"
     },
     "require": {
-        "twbs/bootstrap": "^4",
-        "bordercloud/tether": "^1.1"
+        "twbs/bootstrap": "^4"
     },
     "license": "MIT"
 }

--- a/userpanel/style/bclean/templates/footer.html
+++ b/userpanel/style/bclean/templates/footer.html
@@ -2,8 +2,7 @@
 	{include file="dberrors.html"}
 {/if}
 </div>
-<script src="style/bclean/vendor/bordercloud/tether/dist/js/tether.min.js"></script>
-<script src="style/bclean/vendor/twbs/bootstrap/dist/js/bootstrap.min.js"></script>
+<script src="style/bclean/vendor/twbs/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 
 	$.fn.tooltip.noConflict();

--- a/userpanel/style/bclean/templates/login.html
+++ b/userpanel/style/bclean/templates/login.html
@@ -160,7 +160,7 @@
             </div>
         </div>
         {/if}
-        <script src="style/bclean/vendor/twbs/bootstrap/dist/js/bootstrap.js" type="text/javascript"></script>
+        <script src="style/bclean/vendor/twbs/bootstrap/dist/js/bootstrap.bundle.min.js" type="text/javascript"></script>
         <script>
         $(document).ready(function(){
             $('.toast').toast('show');


### PR DESCRIPTION
- removed tether.js which is deprecated in bootstrap begined from version 4
- bootstrap.js replaced with minified bundle version (which contains Popper.js in order for [tooltips](https://getbootstrap.com/docs/4.0/components/tooltips/) to work)