### PR TITLE
fix: postgresdb

### DIFF
--- a/doc/lms.pgsql
+++ b/doc/lms.pgsql
@@ -1998,7 +1998,7 @@ DROP SEQUENCE IF EXISTS tsigkeys_id_seq;
 CREATE SEQUENCE tsigkeys_id_seq;
 DROP TABLE IF EXISTS tsigkeys CASCADE;
 CREATE TABLE tsigkeys (
-	id				integer DEFAULT nextval('tsigkeys'::text) NOT NULL,
+	id				integer DEFAULT nextval('tsigkeys_id_seq'::text) NOT NULL,
 	name			varchar(255),
 	algorithm		varchar(50),
 	secret			varchar(255),


### PR DESCRIPTION
Likwidacja różnicy między `doc/lms.pgsql` oraz `lib/upgradedb/postgres.2018022600.php`.