### PR TITLE
Zaległe zdarzenia

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -264,7 +264,7 @@ version 25-git (????-??-??):
   - enhancement: added network device assignments tab in network device info
     and edit views [chilan]
   - improvement: added overdue events in another menu item and few fixes with
-  overdue [interduo]
+    overdue [interduo]
 
 version 24.0 (2019-05-16):
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -263,6 +263,8 @@ version 25-git (????-??-??):
     list [chilan]
   - enhancement: added network device assignments tab in network device info
     and edit views [chilan]
+  - improvement: added overdue events in another menu item and few fixes with
+  overdue [interduo]
 
 version 24.0 (2019-05-16):
 

--- a/lib/locale/pl_PL/strings.php
+++ b/lib/locale/pl_PL/strings.php
@@ -115,6 +115,7 @@ $_LANG['Modification'] = 'Modyfikacja';
 $_LANG['Start service'] = 'Uruchomienie usługi';
 $_LANG['Hold service'] = 'Wstrzymanie usługi';
 $_LANG['Overdue events'] = 'Zaległe zdarzenia';
+$_LANG['Overdue events assigned to me'] = 'Zaległe zdarzenia przypisane do mnie';
 $_LANG['Copy'] = 'Kopiuj';
 $_LANG['Only verifier can change this'] = 'Tylko weryfikator może to zmienić';
 $_LANG['<!rt>hours'] = 'godzin';

--- a/lib/menu.php
+++ b/lib/menu.php
@@ -727,6 +727,12 @@ $menu = array(
                     'prio' => 11,
                 ),
                 array(
+                    'name' => trans('Overdue events'),
+                    'link' => '?m=eventlist&overdue_events_only=1',
+                    'tip' => trans('Overdue events'),
+                    'prio' => 12,
+                ),
+                array(
                     'name' => trans('New Event'),
                     'link' => '?m=eventadd',
                     'tip' => trans('New Event Addition'),

--- a/modules/eventlist.php
+++ b/modules/eventlist.php
@@ -129,12 +129,25 @@ $layout['pagetitle'] = trans('Timetable');
 $filter['forward'] = ConfigHelper::getConfig('phpui.timetable_days_forward');
 $eventlist = $LMS->GetEventList($filter);
 
-if (ConfigHelper::checkConfig('phpui.timetable_overdue_events')) {
+$overdue_events_only = isset($_GET['overdue_events_only']) ? 1 : 0;
+
+if (ConfigHelper::checkConfig('phpui.timetable_overdue_events') && empty($overdue_events_only)) {
+    $params['userid'] = Auth::GetCurrentUser();
     $params['forward'] = -1;
     $params['closed'] = 0;
     $params['type'] = 0;
     $overdue_events = $LMS->GetEventList($params);
 }
+
+if (!empty($overdue_events_only)) {
+    unset($params['userid']);
+    $params['forward'] = -1;
+    $params['closed'] = 0;
+    $params['type'] = 0;
+    $overdue_events = $LMS->GetEventList($params);
+}
+
+
 
 // create calendars
 for ($i = 0; $i < ConfigHelper::getConfig('phpui.timetable_days_forward'); $i++) {
@@ -168,6 +181,7 @@ $SMARTY->assign('daylist', $daylist);
 $SMARTY->assign('date', $date);
 $SMARTY->assign('error', $error);
 $SMARTY->assign('userlist', $LMS->GetUserNames());
+$SMARTY->assign('overdue_events_only', $overdue_events_only);
 if (!ConfigHelper::checkConfig('phpui.big_networks')) {
     $SMARTY->assign('customerlist', $LMS->GetCustomerNames());
 }

--- a/modules/eventlist.php
+++ b/modules/eventlist.php
@@ -130,9 +130,10 @@ $filter['forward'] = ConfigHelper::getConfig('phpui.timetable_days_forward');
 $eventlist = $LMS->GetEventList($filter);
 
 if (ConfigHelper::checkConfig('phpui.timetable_overdue_events')) {
-    $filter['forward'] = -1;
-    $filter['closed'] = 0;
-    $overdue_events = $LMS->GetEventList($filter);
+    $params['forward'] = -1;
+    $params['closed'] = 0;
+    $params['type'] = 0;
+    $overdue_events = $LMS->GetEventList($params);
 }
 
 // create calendars

--- a/templates/default/event/eventlist.html
+++ b/templates/default/event/eventlist.html
@@ -7,6 +7,8 @@
     {include file="event/eventlistbox_overdue.html" overdue="1"}
 {/if}
 
+{if empty($overdue_events_only)}
+
 {$eventlist_mode = true}
 
 <H1>{$layout.pagetitle}</H1>
@@ -27,4 +29,5 @@
         {include file="event/eventlistbox.html" overdue="0"}
     </TBODY>
 </TABLE>
+{/if}
 {/block}

--- a/templates/default/event/eventlistbox_overdue.html
+++ b/templates/default/event/eventlistbox_overdue.html
@@ -11,7 +11,7 @@
     <THEAD>
         <TR class="superdark">
             <TD class="bold nobr" colspan="6">
-                <i class="lms-ui-icon-content lms-ui-icon-timetable"></i>{trans("Overdue events")}
+                <i class="lms-ui-icon-content lms-ui-icon-timetable"></i>{trans("Overdue events assigned to me")}
             </TD>
         </TR>
     </THEAD>


### PR DESCRIPTION
Zmiany:
1. W oknie w terminarzu wyświetlamy tylko i wyłącznie zaległe, niezamknięte zdarzenia, przypisane do zalogowanego użytkownika.
2. W menu dodana nowa pozycja zaległe zdarzenia w której wyświetlamy wszystkie zaległe, niezamknięte zdarzenia.
3. Filtry nie działają na zaległe zdarzenia.