### PR TITLE
fix for php notice

### DIFF
--- a/templates/default/document/documenttypes.html
+++ b/templates/default/document/documenttypes.html
@@ -19,7 +19,7 @@
     </THEAD>
     <TBODY>
 	{foreach from=$typelist key=key item=item}
-	<TR class="highlight {cycle}"  >
+	<TR class="highlight">
 		<TD NOWRAP onClick="return self.location.href='?m=documenttypeedit&amp;id={$key}';">
 			<IMG src="img/docum.gif" alt=""> <B>{$item}</B>
 		</TD>


### PR DESCRIPTION
PR usuwa PHP Notice:
`[Wed Apr 22 11:31:58.488772 2020] [php7:notice] [pid 56698] [client 172.20.2.42:60318] PHP Notice:  cycle: missing 'values' parameter in /var/www/html/lms/vendor/smarty/smarty/libs/plugins/function.cycle.php on line 53, referer: https://lms.interduo.pl/?m=documenttypeedit&id=-8
`

Jest jeszcze trochę wystąpień {cycle} 

```
$ grep --count -l -R '{cycle}' templates/default/ | wc -l
63
```

Co nakazuje zrobić ewolucyjne podejście olać czy naprawić?