### PR TITLE
Improvement: Fixed last two icons position in toolbar shortcut

### DIFF
--- a/css/style.less
+++ b/css/style.less
@@ -253,6 +253,7 @@ TABLE		{ border-collapse: collapse; border-color: #000000 }
 
 	.lms-ui-toolbar-shortcut:last-child {
 		margin-left: auto;
+		margin-right: 0.5em;
 		display: flex;
 		justify-content: flex-start;
 	}


### PR DESCRIPTION
Added `margin-right` in `.lms-ui-toolbar-shortcut:last-child` to adapt look with indicators margin.