### PR TITLE
fix: proper outline border size for inner table buttons

### DIFF
--- a/css/style.less
+++ b/css/style.less
@@ -1172,10 +1172,12 @@ a.lms-ui-button:not(.lms-ui-link-button) {
 		text-align: center;
 	}
 	border: 1px solid transparent;
+	display: inline-block;
 	&:hover {
 		cursor: pointer;
 		border: 1px solid @darkbrown;
 		border-radius: 3px;
+		display: inline-block;
 		text-decoration: none;
 	}
 }


### PR DESCRIPTION
To powinno naprawić rozmiar ramki wokół ikon.

Pre:
![pre](https://user-images.githubusercontent.com/56291145/84567274-d08f7f00-ad77-11ea-863a-4a7d1003be18.gif)

Post:
![post](https://user-images.githubusercontent.com/56291145/84567277-d7b68d00-ad77-11ea-8511-26c52d21ab89.gif)
