### PR TITLE
enhancement: allow to disable state changes new->open when adding not…

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -41,7 +41,7 @@ version 26-git (????-??-??):
   - improvement: added phpui.timetable_hide_disabled_users setting
     in eventmodify/eventlistfilter [interduo]
   - enhancement: allow to disable state changes new->open when adding note to
-    ticket - now it depends on variable rt.addnote_change_ticketstate_to_open_after
+    ticket - now it depends on variable rt.change_ticket_state_to_open_after_note_add_interval
     (default:0, whitch keeps current behaviour) [interduo]
 
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -40,7 +40,11 @@ version 26-git (????-??-??):
     is set to 'true' [chilan]
   - improvement: added phpui.timetable_hide_disabled_users setting
     in eventmodify/eventlistfilter [interduo]
-    
+  - enhancement: allow to disable state changes new->open when adding note to
+    ticket - now it depends on variable rt.addnote_change_ticketstate_to_open_after
+    (default:0, whitch keeps current behaviour) [interduo]
+
+
 version 25.0 (2020-05-15):
 
   - improvement: introduced invoices.hide_ssn configuration variable which allows to hide SSN

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -40,10 +40,9 @@ version 26-git (????-??-??):
     is set to 'true' [chilan]
   - improvement: added phpui.timetable_hide_disabled_users setting
     in eventmodify/eventlistfilter [interduo]
-  - enhancement: allow to disable state changes new->open when adding note to
-    ticket - now it depends on variable rt.change_ticket_state_to_open_after_note_add_interval
-    (default:0, whitch keeps current behaviour) [interduo]
-
+  - enhancement: allow to disable state changes new->open when adding note to ticket - now
+    it depends on variable rt.change_ticket_state_to_open_after_note_add_interval
+    (default: 0, which keeps current behaviour) [interduo]
 
 version 25.0 (2020-05-15):
 

--- a/modules/rtnoteadd.php
+++ b/modules/rtnoteadd.php
@@ -267,7 +267,9 @@ if (!isset($_POST['note'])) {
     $note['priority'] = $ticket['priority'];
     $note['verifierid'] = $ticket['verifierid'];
     $note['deadline'] = $ticket['deadline'];
-    if ($note['state'] == RT_NEW) {
+    $notechangestateafter = ConfigHelper::getConfig('rt.change_ticket_state_to_open_after_note_add_interval', 0);
+
+    if ($note['state'] == RT_NEW && (isset($notechangestateafter) && time()-$ticket['createtime'] > $notechangestateafter)) {
         $note['state'] = RT_OPEN;
     }
 }


### PR DESCRIPTION
…e to ticket - now it depends on variable rt.addnote_change_ticketstate_to_open_after (resolves: #1127/LMS+)