### PR TITLE
bugfix: wrong font size

### DIFF
--- a/lib/LMSDocuments/LMSTcpdfDebitNote.php
+++ b/lib/LMSDocuments/LMSTcpdfDebitNote.php
@@ -139,7 +139,7 @@ class LMSTcpdfDebitNote extends LMSTcpdfInvoice
         } elseif ($this->data['ssn']) {
             $recipient .= trans('SSN') . ': ' . $this->data['ssn'];
         }
-        $this->backend->SetFont(self::TCPDF_FONT, '', 10);
+        $this->backend->SetFont(self::TCPDF_FONT, '', 8);
         $this->backend->writeHTMLCell(80, '', 15, 80.5, $recipient, 0, 1, 0, true, 'L');
 
         $y = $this->backend->GetY();


### PR DESCRIPTION
Przed (odbiorca ma za dużą wielkość czcionki względem wystawcy):
![image](https://user-images.githubusercontent.com/56291145/93907938-4c498200-fcfe-11ea-8d1c-644102ae6875.png)

Po (zgodna wielkość (również względem FV)):
![image](https://user-images.githubusercontent.com/56291145/93908074-756a1280-fcfe-11ea-9085-97fe800dedc1.png)
