### PR TITLE
JPK znacznik EE ( usługa telco )

### DIFF
--- a/bin/lms-payments.php
+++ b/bin/lms-payments.php
@@ -1086,7 +1086,7 @@ foreach ($assigns as $assign) {
 
         $val = str_replace(',', '.', sprintf("%.2f", $val));
 
-        $telecom_service = $force_telecom_service_flag && $assign['customertype'] == CTYPES_PRIVATE && $assign['tarifftype'] != SERVICE_OTHER;
+        $telecom_service = $force_telecom_service_flag && ( $assign['customertype'] == CTYPES_PRIVATE || $assign['customertype'] == CTYPES_COMPANY ) && $assign['tarifftype'] != SERVICE_OTHER;
 
         if ($assign['invoice']) {
             if ($assign['a_paytype']) {


### PR DESCRIPTION
Konsultowałem się z księgowym i wydaje mi się ze warunek przy jakim skrypt ustawi w fakturze ww. flagę jest niewłaściwy.
Jeśli dobrze rozumiem (pomijając pierwszą flagę która jest z konfiguracji i jest domyślnie TRUE) aby znacznik się taki znalazł taryfa ma być inna niż typu "inna" a klient ma być osobą fizyczną. 
No i właśnie tu jest moim zdaniem błąd, znacznik EE powiem być  na fakturach osoby fizycznej i prawnej, czyli dla wszystkich, Babci też ;)