### PR TITLE
bugfix: subject with quotes are propper displayed in rtticketinfobox

### DIFF
--- a/lib/LMSManagers/LMSHelpdeskManager.php
+++ b/lib/LMSManagers/LMSHelpdeskManager.php
@@ -1210,6 +1210,7 @@ class LMSHelpdeskManager extends LMSManager implements LMSHelpdeskManagerInterfa
 
         $ticket['parent'] = $this->getTickets($ticket['parentid']);
         $ticket['relatedtickets'] = $this->GetRelatedTickets($id);
+        $ticket['subject'] = htmlspecialchars_decode($ticket['subject']);
 
         if (!$short) {
             $ticket['messages'] = $this->db->GetAll(

--- a/templates/default/rt/rtticketinfobox.html
+++ b/templates/default/rt/rtticketinfobox.html
@@ -51,7 +51,7 @@
 									<i class="lms-ui-icon-content lms-ui-icon-subject"></i>{trans("Subject:")}
 								</TD>
 								<TD style="width: 99%;" class="nobr">
-									{$ticket.subject|escape|truncate:50:"...":true}
+									{$ticket.subject|truncate:50:"...":true}
 								</TD>
 							</TR>
 							{if $ticket.service != SERVICE_OTHER}


### PR DESCRIPTION
W rtqueueview widać często `&raquo` po wyrzuceniu `|escape` ze smarty problemu już nie ma - przenoszę to na backend. Proszę o testy tego. 