### PR TITLE
devel: add name_custom_contents to allow show extra data in invoice p…

### DIFF
--- a/templates/default/invoice/invoicecontents.html
+++ b/templates/default/invoice/invoicecontents.html
@@ -99,6 +99,9 @@
                        value="{htmlspecialchars($row.name)}" data-old-value="{htmlspecialchars($item.name)}"
                        {tip text="Enter description"}>
                 <span class="invoice-contents-field-value">{$item.name}</span>
+                {if isset($item.name_custom_contents)}
+                    {$item.name_custom_contents}
+                {/if}
             </TD>
             <TD class="nobr">
                 {tax_category_selection class="invoice-contents-field-edit" elementname="invoice-contents["|cat:$posuid|cat:"][taxcategory]"


### PR DESCRIPTION
…osition

To coś na podobieństwo 'valuenetto_custom_contents', które kiedyś było dodane na potrzeby magazynu. Pozwoli to na umieszczenie w pozycji faktury, która zawiera produkt z egzemplarzami z magazynu, informacji o tym jakie egzemplarze zostały dodane do faktury (Na razie to egzemplarze widać tylko przy dodawaniu pozycji faktury, ale już po dodaniu nie ma żadnej informacji o tym). 