### PR TITLE
devel: index contents[] respectively to invoice[content] in invoice e…

### DIFF
--- a/modules/invoiceedit.php
+++ b/modules/invoiceedit.php
@@ -67,7 +67,8 @@ if (isset($_GET['id']) && ($action == 'edit' || $action == 'init')) {
 
     $invoicecontents = array();
     foreach ($invoice['content'] as $item) {
-        $invoicecontents[] = array(
+        $invoicecontents[$item['itemid']] = array(
+            'itemid' => $item['itemid'],
             'tariffid' => $item['tariffid'],
             'name' => $item['description'],
             'prodid' => $item['prodid'],
@@ -137,7 +138,7 @@ function changeContents($contents, $newcontents)
 
     foreach ($newcontents as $posuid => &$newposition) {
         if (isset($contents[$posuid])) {
-            $result[] = $contents[$posuid];
+            $result[$posuid] = $contents[$posuid];
         }
     }
     unset($newposition);


### PR DESCRIPTION
…dit to allow bind them each other

Co wnosi PR na konkretnym przykładzie:
Rozpoczynamy edycję faktury z jedną pozycją. W momencie inicjacji edycji do hooka trafia
`$hook_data = array(
            'contents' => $contents,
            'invoice' => $invoice,
        );`
Jednak ta pozycja faktury w $hook_data['contents'] jest zapisana w indeksie '0', natomiast w $hook_data['invoice']['content'] w indeksie '1' i nie ma przy tym żadnego powiązania między tymi danymi oprócz nazwy pozycji. Czyli nie ma prostej możliwości sprawdzenia, czy po inicjacji faktury do edycji nie nastąpiły jakieś zmiany (np. czy nie usunięto pozycji). Sprawdzenie czy nie usunięto pozycji jest istotne np. dla magazynu gdzie w hooku 'invoiceedit_save_validation' trzeba sprawdzić, czy w przypadku edycji faktury, do której wystawiono WZ, nie zostanie usunięta pozycja magazynowa. Poprawka pozwala na indeksowanie $hook_data['contents'] identycznie z $hook_data['invoice']['content'] i dodatkowo wprowadza 'itemid' jako klucz połączenia. Dzięki temu będzie można łatwo powiązać stan pozycji po inicjacji ze stanem pozycji w momencie zapisu edytowanej faktury.

Generalnie zmieniany jest sposób indeksowania $hook_data['contents'] z zaczynającego się od '0' na zaczynający się od '1', co dla reszty kodu wydaje się nie mieć znaczenia i działa.

Zmiana głównie spowodowana potrzebami magazynu, dlatego najbardziej będzie potrzebna w stable i stable-24 (dlatego daje flagi), ale jak nie przejdzie, to poradzę w magazynie w inny sposób (choć mniej wydajny i przejrzysty). 

