### PR TITLE
devel: add alert to currency selection when default currency is not d…

### DIFF
--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -98,7 +98,7 @@ class LMSSmartyPlugins
                 . (isset($params['form']) ? ' form="' . $params['form'] . '"' : '') . '>';
             foreach ($GLOBALS['CURRENCIES'] as $currency) {
                 $result .= '<option value="' . $currency . '"'
-                    . ($currency == $selected || $currency == $defaultSelected ? ' selected' : '') . '>' . $currency . '</option>';
+                . (($selected && $currency == $selected) || (!$selected && $currency == $defaultSelected)  ? ' selected' : '') . '>' . $currency . '</option>';
             }
             $result .= '</select>';
         } else {

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -91,7 +91,7 @@ class LMSSmartyPlugins
             ? $params['selected'] : null;
         $locked = isset($params['locked']) && $params['locked'];
         if (function_exists('get_currency_value') && !$locked) {
-            $result = '<select name="' . $elementname . '" ' . self::tipFunction(array('text' => 'Select currency'), $template)
+            $result = '<select class="'. (!$selected ? 'alert' : '') .'" name="' . $elementname . '" ' . self::tipFunction(array('text' => 'Select currency'), $template)
                 . (isset($params['form']) ? ' form="' . $params['form'] . '"' : '') . '>';
             foreach ($GLOBALS['CURRENCIES'] as $currency) {
                 $result .= '<option value="' . $currency . '"'

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -89,13 +89,16 @@ class LMSSmartyPlugins
         $elementname = isset($params['elementname']) ? $params['elementname'] : 'currency';
         $selected = isset($params['selected']) && isset($GLOBALS['CURRENCIES'][$params['selected']])
             ? $params['selected'] : null;
+        $defaultSelected = Localisation::getCurrentCurrency();
         $locked = isset($params['locked']) && $params['locked'];
         if (function_exists('get_currency_value') && !$locked) {
-            $result = '<select class="'. (!$selected ? 'alert' : '') .'" name="' . $elementname . '" ' . self::tipFunction(array('text' => 'Select currency'), $template)
+            $result = '<select class="'. (!$selected ? 'lms-ui-warning' : '')
+                .'" name="' . $elementname . '" '
+                . self::tipFunction(array('text' => !$selected ? 'Select currency and save' : 'Select currency'), $template)
                 . (isset($params['form']) ? ' form="' . $params['form'] . '"' : '') . '>';
             foreach ($GLOBALS['CURRENCIES'] as $currency) {
                 $result .= '<option value="' . $currency . '"'
-                    . ($currency == $selected ? ' selected' : '') . '>' . $currency . '</option>';
+                    . ($currency == $selected || $currency == $defaultSelected ? ' selected' : '') . '>' . $currency . '</option>';
             }
             $result .= '</select>';
         } else {

--- a/lib/locale/pl_PL/strings.php
+++ b/lib/locale/pl_PL/strings.php
@@ -4783,6 +4783,7 @@ $_LANG['Copy rights'] = 'Kopiuj uprawnienia';
 $_LANG['of selected user:'] = 'wybranego użytkownika:';
 
 $_LANG['Select currency'] = 'Wybierz walutę';
+$_LANG['Select currency and save'] = 'Wybierz walutę i zapisz';
 $_LANG['Invalid currency selection!'] = 'Błędny wybór waluty!';
 $_LANG['Currency:'] = 'Waluta:';
 


### PR DESCRIPTION
…efined

Przykładowo, jeśli mamy taryfę bez przypisanej waluty i ją edytujemy, to domyślnie do wyboru waluty podpowiada się pierwsza z listy. Dziś w jednej firmie był taki przypadek. Zmiana dodaje do 'select' alert żeby zwrócić uwagę, że potrzebna jest reakcja użytkownika i wybór odpowiedniej waluty.

![Zrzut ekranu z 2021-01-21 21-07-06](https://user-images.githubusercontent.com/7595420/105406386-a4e94700-5c2c-11eb-8378-ff3b408f915e.png)

Generalnie oprócz wspomnianego powyżej przypadku waluta jest inicjowana wcześniej np. '$invoice['currency'] = Localisation::getDefaultCurrency();' więc alert raczej nie wystąpi, ale jeśli takiej inicjacji nie ma, to przynajmniej użytkownik nie przegapi takiego ostrzeżenia i dokona odpowiedniego wyboru waluty.