### PR TITLE
bugfix: remove unnecessary 'all users' selection when overlapping eve…

### DIFF
--- a/modules/eventedit.php
+++ b/modules/eventedit.php
@@ -249,7 +249,7 @@ if (isset($event['customerid']) && intval($event['customerid'])) {
 }
 
 if (!isset($event['usergroup'])) {
-    $event['usergroup'] = 0;
+    $event['usergroup'] = -2;
 }
     //$SESSION->restore('eventgid', $event['usergroup']);
 


### PR DESCRIPTION
…nt warning occurs -fix (LMS+ #1665)