### PR TITLE
enhancement: added assignments color markings to a tooltip

### DIFF
--- a/css/less/icons.less
+++ b/css/less/icons.less
@@ -1743,3 +1743,12 @@
     content: @fa-var-filter;
   }
 }
+
+.lms-ui-icon-tiphelp {
+  .fa-icon;
+  .fas;
+  .lms-ui-icon;
+  &:before {
+    content: @fa-var-question-circle;
+  }
+}

--- a/lib/locale/pl_PL/strings.php
+++ b/lib/locale/pl_PL/strings.php
@@ -5103,7 +5103,8 @@ $_LANG['with locks'] = 'z blokadami';
 $_LANG['<!node>lock is active'] = 'blokada jest aktywna';
 
 $_LANG['Assignments colors markings'] = 'Legenda oznaczeń';
-$_LANG['Active assignment'] = 'Zobowiązanie aktywne';
+$_LANG['Active tariff assignment'] = 'Zobowiązanie taryfowe aktywne';
+$_LANG['Active tariffless assignment'] = 'Zobowiązanie beztaryfowe aktywne';
 $_LANG['Suspended assignment'] = 'Zobowiązanie zawieszone';
 $_LANG['Future assignment'] = 'Zobowiązanie przyszłe';
 $_LANG['Expired assignment'] = 'Zobowiązanie przeterminowane';

--- a/lib/locale/pl_PL/strings.php
+++ b/lib/locale/pl_PL/strings.php
@@ -5101,3 +5101,10 @@ $_LANG['with tariffless liabilities'] = 'z zobowiązaniami beztaryfowymi';
 $_LANG['with locks'] = 'z blokadami';
 
 $_LANG['<!node>lock is active'] = 'blokada jest aktywna';
+
+$_LANG['Assignments colors markings'] = 'Legenda oznaczeń';
+$_LANG['Active assignment'] = 'Zobowiązanie aktywne';
+$_LANG['Suspended assignment'] = 'Zobowiązanie zawieszone';
+$_LANG['Future assignment'] = 'Zobowiązanie przyszłe';
+$_LANG['Expired assignment'] = 'Zobowiązanie przeterminowane';
+$_LANG['Assignment from not approved document'] = 'Zobowiązanie z niezatwierdzonego dokumentu';

--- a/templates/default/customer/customerassignments.html
+++ b/templates/default/customer/customerassignments.html
@@ -44,7 +44,19 @@
 				<input type="checkbox" class="commited" value="1"{if $commited} checked{/if}>
 			</label>
 			<a class="clear-filter lms-ui-button" href="#"><i class="lms-ui-icon-delete"></i></a>
-			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong><br><br><span style='color:maroon'><strong>{trans("Active tariff assignment")}</strong></span><br><strong>{trans("Active tariffless assignment")}</strong><br><span class='suspended'><strong>{trans("Suspended assignment")}</strong></span><br><span class='alertblend'><strong>{trans("Future assignment")}</strong></span><br><span class='blend'><strong>{trans("Expired assignment")}</strong></span><br><span class='lms-ui-assignment-not-commited'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
+			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong>
+			<br><br>
+			<span style='color:maroon'><strong>{trans("Active tariff assignment")}</strong></span>
+			<br>
+			<strong>{trans("Active tariffless assignment")}</strong>
+			<br>
+			<span class='suspended'><strong>{trans("Suspended assignment")}</strong></span>
+			<br>
+			<span class='alertblend'><strong>{trans("Future assignment")}</strong></span>
+			<br>
+			<span class='blend'><strong>{trans("Expired assignment")}</strong></span>
+			<br>
+			<span class='lms-ui-assignment-not-commited'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
 		{/tab_header_cell}
 		{tab_header_cell}
 			{if !$customerinfo.deleted}

--- a/templates/default/customer/customerassignments.html
+++ b/templates/default/customer/customerassignments.html
@@ -44,6 +44,7 @@
 				<input type="checkbox" class="commited" value="1"{if $commited} checked{/if}>
 			</label>
 			<a class="clear-filter lms-ui-button" href="#"><i class="lms-ui-icon-delete"></i></a>
+			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong><br><br><strong>{trans("Active assignment")}</strong><br><span class='suspended'><strong>{trans("Suspended assignment")}</strong></span><br><span class='alertblend'><strong>{trans("Future assignment")}</strong></span><br><span class='blend'><strong>{trans("Expired assignment")}</strong></span><br><span class=\'lms-ui-assignment-not-commited\'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
 		{/tab_header_cell}
 		{tab_header_cell}
 			{if !$customerinfo.deleted}

--- a/templates/default/customer/customerassignments.html
+++ b/templates/default/customer/customerassignments.html
@@ -44,7 +44,7 @@
 				<input type="checkbox" class="commited" value="1"{if $commited} checked{/if}>
 			</label>
 			<a class="clear-filter lms-ui-button" href="#"><i class="lms-ui-icon-delete"></i></a>
-			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong><br><br><strong>{trans("Active assignment")}</strong><br><span class='suspended'><strong>{trans("Suspended assignment")}</strong></span><br><span class='alertblend'><strong>{trans("Future assignment")}</strong></span><br><span class='blend'><strong>{trans("Expired assignment")}</strong></span><br><span class='lms-ui-assignment-not-commited'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
+			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong><br><br><span style='color:maroon'><strong>{trans("Active tariff assignment")}</strong></span><br><strong>{trans("Active tariffless assignment")}</strong><br><span class='suspended'><strong>{trans("Suspended assignment")}</strong></span><br><span class='alertblend'><strong>{trans("Future assignment")}</strong></span><br><span class='blend'><strong>{trans("Expired assignment")}</strong></span><br><span class='lms-ui-assignment-not-commited'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
 		{/tab_header_cell}
 		{tab_header_cell}
 			{if !$customerinfo.deleted}

--- a/templates/default/customer/customerassignments.html
+++ b/templates/default/customer/customerassignments.html
@@ -44,7 +44,7 @@
 				<input type="checkbox" class="commited" value="1"{if $commited} checked{/if}>
 			</label>
 			<a class="clear-filter lms-ui-button" href="#"><i class="lms-ui-icon-delete"></i></a>
-			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong><br><br><strong>{trans("Active assignment")}</strong><br><span class='suspended'><strong>{trans("Suspended assignment")}</strong></span><br><span class='alertblend'><strong>{trans("Future assignment")}</strong></span><br><span class='blend'><strong>{trans("Expired assignment")}</strong></span><br><span class=\'lms-ui-assignment-not-commited\'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
+			{button type="link" icon="tiphelp" tip="<strong>{trans("Assignments colors markings")}:</strong><br><br><strong>{trans("Active assignment")}</strong><br><span class='suspended'><strong>{trans("Suspended assignment")}</strong></span><br><span class='alertblend'><strong>{trans("Future assignment")}</strong></span><br><span class='blend'><strong>{trans("Expired assignment")}</strong></span><br><span class='lms-ui-assignment-not-commited'><strong>{trans("Assignment from not approved document")}</strong></span>" href=""}
 		{/tab_header_cell}
 		{tab_header_cell}
 			{if !$customerinfo.deleted}


### PR DESCRIPTION
Dodałem małą pomoc dla każdego pracownika BOK, do panelu **_Zobowiązania klienta_** w **_karcie klienta_**.

Doszła nowa ikona w CSS, o której myślałem, aby dodawać ją w miejscach gdzie taka pomoc by się przydała.

Wygląda to tak:
![image](https://user-images.githubusercontent.com/56291145/107985280-15844900-6fca-11eb-9edd-4410c5200f52.png)

Po najechaniu kursorem na ikonę, pokazuje się tooltip z oznaczeniami wszystkich kolorów/stylów zobowiązań. Myślę, że pomocne.