### PR TITLE
improvement: allow to hide 'don't scale images' option through Smarty…

### DIFF
--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -329,6 +329,7 @@ class LMSSmartyPlugins
         }
 
         $form = isset($params['form']) ? $params['form'] : null;
+        $imageResizeOption = isset($params['imageResizeOption']) && empty($params['imageResizeOption']) ? false : true;
 
         // special treatment of file upload errors marked in error associative array
         $tmpl = $template->getTemplateVars('error');
@@ -353,7 +354,7 @@ class LMSSmartyPlugins
 				<button type="button" class="lms-ui-button-fileupload lms-ui-button' . (isset($error_tip_params) ? ' lms-ui-error' : '') . '" id="' . $id . '_button" '
             . (isset($error_tip_params) ? self::tipFunction($error_tip_params, $template) : '') . '><i class="lms-ui-icon-fileupload"></i><span class="lms-ui-label">' . trans("Select files") . '</span></button>
 				<INPUT name="' . $id . '[]" type="file" multiple class="fileupload-select-btn" style="display: none;" ' . ($form ? ' form="' . $form . '"' : '') . '>
-				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && !isset($params['hideNoImageResizeOption'])
+				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && $imageResizeOption
                     ? '<label><input type="checkbox" class="dont-scale-images" value="1">' . trans("don't scale images") . '</label>'
                     : '') . '
 			</div>

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -329,7 +329,7 @@ class LMSSmartyPlugins
         }
 
         $form = isset($params['form']) ? $params['form'] : null;
-        $image_resize = isset($params['image_resize']) && empty($params['image_resize']) ? false : true;
+        $image_resize = !isset($params['image_resize']) || !empty($params['image_resize']);
 
         // special treatment of file upload errors marked in error associative array
         $tmpl = $template->getTemplateVars('error');

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -353,7 +353,7 @@ class LMSSmartyPlugins
 				<button type="button" class="lms-ui-button-fileupload lms-ui-button' . (isset($error_tip_params) ? ' lms-ui-error' : '') . '" id="' . $id . '_button" '
             . (isset($error_tip_params) ? self::tipFunction($error_tip_params, $template) : '') . '><i class="lms-ui-icon-fileupload"></i><span class="lms-ui-label">' . trans("Select files") . '</span></button>
 				<INPUT name="' . $id . '[]" type="file" multiple class="fileupload-select-btn" style="display: none;" ' . ($form ? ' form="' . $form . '"' : '') . '>
-				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0)
+				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && !isset($params['disableImageResize'])
                     ? '<label><input type="checkbox" class="dont-scale-images" value="1">' . trans("don't scale images") . '</label>'
                     : '') . '
 			</div>

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -353,7 +353,7 @@ class LMSSmartyPlugins
 				<button type="button" class="lms-ui-button-fileupload lms-ui-button' . (isset($error_tip_params) ? ' lms-ui-error' : '') . '" id="' . $id . '_button" '
             . (isset($error_tip_params) ? self::tipFunction($error_tip_params, $template) : '') . '><i class="lms-ui-icon-fileupload"></i><span class="lms-ui-label">' . trans("Select files") . '</span></button>
 				<INPUT name="' . $id . '[]" type="file" multiple class="fileupload-select-btn" style="display: none;" ' . ($form ? ' form="' . $form . '"' : '') . '>
-				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && !isset($params['disableImageResize'])
+				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && !isset($params['hideNoImageResizeOption'])
                     ? '<label><input type="checkbox" class="dont-scale-images" value="1">' . trans("don't scale images") . '</label>'
                     : '') . '
 			</div>

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -329,7 +329,7 @@ class LMSSmartyPlugins
         }
 
         $form = isset($params['form']) ? $params['form'] : null;
-        $imageResizeOption = isset($params['imageResizeOption']) && empty($params['imageResizeOption']) ? false : true;
+        $image_resize = isset($params['image_resize']) && empty($params['image_resize']) ? false : true;
 
         // special treatment of file upload errors marked in error associative array
         $tmpl = $template->getTemplateVars('error');
@@ -354,7 +354,7 @@ class LMSSmartyPlugins
 				<button type="button" class="lms-ui-button-fileupload lms-ui-button' . (isset($error_tip_params) ? ' lms-ui-error' : '') . '" id="' . $id . '_button" '
             . (isset($error_tip_params) ? self::tipFunction($error_tip_params, $template) : '') . '><i class="lms-ui-icon-fileupload"></i><span class="lms-ui-label">' . trans("Select files") . '</span></button>
 				<INPUT name="' . $id . '[]" type="file" multiple class="fileupload-select-btn" style="display: none;" ' . ($form ? ' form="' . $form . '"' : '') . '>
-				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && $imageResizeOption
+				' . (ConfigHelper::getConfig('phpui.uploaded_image_max_size', 0) && $image_resize
                     ? '<label><input type="checkbox" class="dont-scale-images" value="1">' . trans("don't scale images") . '</label>'
                     : '') . '
 			</div>

--- a/templates/default/config/configimport.html
+++ b/templates/default/config/configimport.html
@@ -15,7 +15,7 @@
 
 {box_container id="config"}
 	{box_header}
-		{fileupload id="files" fileupload=$fileupload form="configimport" imageResizeOption=""}
+		{fileupload id="files" fileupload=$fileupload form="configimport" image_resize=""}
 	{/box_header}
 
 	{box_contents}

--- a/templates/default/config/configimport.html
+++ b/templates/default/config/configimport.html
@@ -15,7 +15,7 @@
 
 {box_container id="config"}
 	{box_header}
-		{fileupload id="files" fileupload=$fileupload form="configimport" image_resize=""}
+		{fileupload id="files" fileupload=$fileupload form="configimport" image_resize=false}
 	{/box_header}
 
 	{box_contents}

--- a/templates/default/config/configimport.html
+++ b/templates/default/config/configimport.html
@@ -15,7 +15,7 @@
 
 {box_container id="config"}
 	{box_header}
-		{fileupload id="files" fileupload=$fileupload form="configimport"}
+		{fileupload id="files" fileupload=$fileupload form="configimport" hideNoImageResizeOption=""}
 	{/box_header}
 
 	{box_contents}

--- a/templates/default/config/configimport.html
+++ b/templates/default/config/configimport.html
@@ -15,7 +15,7 @@
 
 {box_container id="config"}
 	{box_header}
-		{fileupload id="files" fileupload=$fileupload form="configimport" hideNoImageResizeOption=""}
+		{fileupload id="files" fileupload=$fileupload form="configimport" imageResizeOption=""}
 	{/box_header}
 
 	{box_contents}


### PR DESCRIPTION
… parameter 'hideNoImageResizeOption' in 'fileUploadFunction'

To na potrzeby późniejszego zastosowania w imporcie konfiguracji do wyboru plików gdzie skalowanie obrazków nie ma w ogóle zastosowania. Wywołanie będzie wyglądać tak: 
`{fileupload id="files" fileupload=$fileupload form="configimport" hideNoImageResizeOption=""}`