### PR TITLE
improvement: adds fa spacer CSS class

### DIFF
--- a/css/less/icons.less
+++ b/css/less/icons.less
@@ -37,7 +37,13 @@
 }
 
 .lms-ui-icon-spacer {
-  color: transparent;
+  .fa-icon;
+  .fas;
+  .lms-ui-icon;
+  &:before {
+    content: @fa-var-circle;
+    color: transparent;
+  }
 }
 
 .lms-ui-icon-map-pin {

--- a/css/less/icons.less
+++ b/css/less/icons.less
@@ -36,6 +36,10 @@
   text-align: center;
 }
 
+.lms-ui-icon-spacer {
+  color: transparent;
+}
+
 .lms-ui-icon-map-pin {
   .fa-icon;
   .fas;

--- a/templates/default/customer/customersearch.html
+++ b/templates/default/customer/customersearch.html
@@ -439,7 +439,7 @@
 	</TR>
 	<TR>
 		<TD class="bold nobr">
-			{icon name="modified-date" fw=true class="lms-ui-icon-spacer"} {trans("Qualification operator:")}
+			{icon name="spacer" fw=true} {trans("Qualification operator:")}
 		</TD>
 		<TD>
 			<INPUT class="radio light" type="radio" id="operator0" value="AND" name="k"{if $k!='OR'} CHECKED{/if}><label for="operator0">{trans("and")}</label>

--- a/templates/default/customer/customersearch.html
+++ b/templates/default/customer/customersearch.html
@@ -439,7 +439,7 @@
 	</TR>
 	<TR>
 		<TD class="bold nobr">
-			<IMG src="img/empty.gif" width="16" alt=""> {trans("Qualification operator:")}
+			{icon name="modified-date" fw=true class="lms-ui-icon-spacer"} {trans("Qualification operator:")}
 		</TD>
 		<TD>
 			<INPUT class="radio light" type="radio" id="operator0" value="AND" name="k"{if $k!='OR'} CHECKED{/if}><label for="operator0">{trans("and")}</label>


### PR DESCRIPTION
This very simple and neat hack adds CSS class which sets any icon to transparent color, thus with it, we have empty/blank fa icon, which can be used as an spacer and also it will maintain fixed width with other used icons.

As an example I've used it to replace spacer in customersearch form.