### PR TITLE
bugfix: chrome/ff dont save passwords

### DIFF
--- a/templates/default/twofactorauth/twofactorauthcode.html
+++ b/templates/default/twofactorauth/twofactorauthcode.html
@@ -78,7 +78,7 @@
 						{trans("Authentication code:")}
 					</td>
 					<td>
-						<input class="bold" type="number" name="authcodeform[authcode]" size="10" accesskey="l" autofocus autocomplete="false">
+						<input class="bold" type="number" name="authcodeform[authcode]" size="10" accesskey="l" autofocus autocomplete="new-password">
 					</td>
 				</tr>
 				<tr>

--- a/templates/default/twofactorauth/twofactorauthcode.html
+++ b/templates/default/twofactorauth/twofactorauthcode.html
@@ -78,7 +78,7 @@
 						{trans("Authentication code:")}
 					</td>
 					<td>
-						<input class="bold" type="number" name="authcodeform[authcode]" size="10" accesskey="l" autofocus autocomplete="off">
+						<input class="bold" type="number" name="authcodeform[authcode]" size="10" accesskey="l" autofocus autocomplete="false">
 					</td>
 				</tr>
 				<tr>

--- a/templates/default/user/useradd.html
+++ b/templates/default/user/useradd.html
@@ -101,7 +101,7 @@
 			</>
 			<td>
 				<input type="email" name="useradd[email]" value="{$useradd.email}" size="40"
-					{tip text="Enter e-mail address (optional)" trigger="email"} autocomplete="false">
+					{tip text="Enter e-mail address (optional)" trigger="email"} autocomplete="new-password">
 			</td>
 		</tr>
 		<tr>
@@ -157,10 +157,10 @@
 				{trans('from')}:
 				<input type="text" name="useradd[accessfrom]" value="{if $useradd.accessfrom}{$useradd.accessfrom}{/if}"
 					size="10" placeholder="{trans("yyyy/mm/dd")}"
-					{tip class="lms-ui-date" text="Enter access start date in YYYY/MM/DD format. If you don't want to define 'From' date leave this field empty" trigger="accessfrom"} autocomplete="false">
+					{tip class="lms-ui-date" text="Enter access start date in YYYY/MM/DD format. If you don't want to define 'From' date leave this field empty" trigger="accessfrom"} autocomplete="new-password">
 				{trans('to')}:
 				<input type="text" name="useradd[accessto]" value="{if $useradd.accessto}{$useradd.accessto}{/if}"
-					size="10" placeholder="{trans("yyyy/mm/dd")}" autocomplete="false"
+					size="10" placeholder="{trans("yyyy/mm/dd")}" autocomplete="new-password"
 					{tip class="lms-ui-date" text="Enter access end date in YYYY/MM/DD format. If you don't want to define 'To' date leave this field empty" trigger="accessto"}>
 			</td>
 		</tr>

--- a/templates/default/user/useradd.html
+++ b/templates/default/user/useradd.html
@@ -101,7 +101,7 @@
 			</>
 			<td>
 				<input type="email" name="useradd[email]" value="{$useradd.email}" size="40"
-					{tip text="Enter e-mail address (optional)" trigger="email"}>
+					{tip text="Enter e-mail address (optional)" trigger="email"} autocomplete="false">
 			</td>
 		</tr>
 		<tr>
@@ -157,10 +157,10 @@
 				{trans('from')}:
 				<input type="text" name="useradd[accessfrom]" value="{if $useradd.accessfrom}{$useradd.accessfrom}{/if}"
 					size="10" placeholder="{trans("yyyy/mm/dd")}"
-					{tip class="lms-ui-date" text="Enter access start date in YYYY/MM/DD format. If you don't want to define 'From' date leave this field empty" trigger="accessfrom"} autocomplete="off">
+					{tip class="lms-ui-date" text="Enter access start date in YYYY/MM/DD format. If you don't want to define 'From' date leave this field empty" trigger="accessfrom"} autocomplete="false">
 				{trans('to')}:
 				<input type="text" name="useradd[accessto]" value="{if $useradd.accessto}{$useradd.accessto}{/if}"
-					size="10" placeholder="{trans("yyyy/mm/dd")}" autocomplete="off"
+					size="10" placeholder="{trans("yyyy/mm/dd")}" autocomplete="false"
 					{tip class="lms-ui-date" text="Enter access end date in YYYY/MM/DD format. If you don't want to define 'To' date leave this field empty" trigger="accessto"}>
 			</td>
 		</tr>
@@ -170,7 +170,7 @@
 				<strong>{trans("Password:")}</strong>
 			</td>
 			<td>
-				<input type="password" name="useradd[password]" required {tip text="Enter password" trigger="password"} autocomplete="off">
+				<input type="password" name="useradd[password]" required {tip text="Enter password" trigger="password"} autocomplete="new-password">
 			</td>
 		</tr>
 		<tr>
@@ -179,7 +179,7 @@
 				<strong>{trans("Repeat password:")}</strong>
 			</td>
 			<td>
-				<input type="password" name="useradd[confirm]" required {tip text="Confirm password" trigger="password"} autocomplete="off">
+				<input type="password" name="useradd[confirm]" required {tip text="Confirm password" trigger="password"} autocomplete="new-password">
 			</td>
 		</tr>
 		<tr>

--- a/templates/default/user/userpasswd.html
+++ b/templates/default/user/userpasswd.html
@@ -22,7 +22,7 @@
 			{trans("Current password:")}
 		</TD>
 		<TD class="nobr">
-			<input type="password" name="password[currentpasswd]" {tip text="Enter current password" trigger="currentpasswd"} autocomplete="off">
+			<input type="password" name="password[currentpasswd]" {tip text="Enter current password" trigger="currentpasswd"} autocomplete="new-password">
 		</TD>
 	</TR>
 	{/if}
@@ -31,7 +31,7 @@
 			{trans("New password:")}
 		</TD>
 		<TD class="nobr">
-			<input type="password" name="password[passwd]" {tip text="Enter password" trigger="passwd"} autocomplete="off">
+			<input type="password" name="password[passwd]" {tip text="Enter password" trigger="passwd"} autocomplete="new-password">
 		</TD>
 	</TR>
 	<TR>
@@ -39,7 +39,7 @@
 			{trans("Repeat password:")}
 		</TD>
 		<TD class="nobr">
-			<input type="password" name="password[confirm]" {tip text="Confirm password" trigger="passwd"} autocomplete="off">
+			<input type="password" name="password[confirm]" {tip text="Confirm password" trigger="passwd"} autocomplete="new-password">
 		</TD>
 	</TR>
 	<TR>

--- a/templates/default/user/userpasswd.html
+++ b/templates/default/user/userpasswd.html
@@ -22,7 +22,7 @@
 			{trans("Current password:")}
 		</TD>
 		<TD class="nobr">
-			<input type="password" name="password[currentpasswd]" {tip text="Enter current password" trigger="currentpasswd"} autocomplete="new-password">
+			<input type="password" name="password[currentpasswd]" {tip text="Enter current password" trigger="currentpasswd"} {if $passwd.id == $layout.logid}autocomplete="current-password"{else}autocomplete="new-password"{/if}>
 		</TD>
 	</TR>
 	{/if}

--- a/templates/default/user/userpasswd.html
+++ b/templates/default/user/userpasswd.html
@@ -22,7 +22,7 @@
 			{trans("Current password:")}
 		</TD>
 		<TD class="nobr">
-			<input type="password" name="password[currentpasswd]" {tip text="Enter current password" trigger="currentpasswd"} {if $passwd.id == $layout.logid}autocomplete="current-password"{else}autocomplete="new-password"{/if}>
+			<input type="password" name="password[currentpasswd]" {tip text="Enter current password" trigger="currentpasswd"} autocomplete="{if $passwd.id == $layout.logid}current-password{else}new-password{/if}">
 		</TD>
 	</TR>
 	{/if}


### PR DESCRIPTION
To jest po to by przeglądarki nie dopełniały pola zapisanymi wartościami - w tym formularzu jest to totalnie zbędne.

A autocomplete='off' po prostu przestał działać od którejś wersji w Chrome.