### PR TITLE
security: fix privilege escalation in login#target switch-user gate

### DIFF
--- a/lib/Auth.class.php
+++ b/lib/Auth.class.php
@@ -130,10 +130,18 @@ class Auth
                 $components = explode('#', $loginform['login']);
                 $this->login = $login = $components[0];
                 $targetLogin = count($components) == 2 ? $components[1] : null;
+                // 'login#targetlogin' lets an admin instantly switch into another
+                // user's session (ChangeLog: "allow to instantly switch user or
+                // login as different user"). The gate below used to check whether
+                // ANY full_access user existed anywhere in the system, not whether
+                // the authenticating login ($login) itself had full_access — so any
+                // operator who knew an admin's login could switch INTO that admin
+                // account using their own password. Scope the check to $login.
                 if (!empty($targetLogin)
                     && $this->DB->GetOne(
-                        'SELECT 1 FROM users WHERE deleted = 0 AND access = 1 AND '
-                        . $this->DB->RegExp('rights', 'full_access')
+                        'SELECT 1 FROM users WHERE login = ? AND deleted = 0 AND access = 1 AND '
+                        . $this->DB->RegExp('rights', 'full_access'),
+                        array($login)
                     )
                 ) {
                     $this->targetLogin = $targetLogin;


### PR DESCRIPTION
## Summary
- `Auth.class.php`'s `login#targetlogin` switch-user feature (see ChangeLog: "allow to instantly switch user or login as different user") gates on whether *any* `full_access` user exists in the system, not whether the *authenticating* login has `full_access`.
- Any authenticated operator who knows an admin's login can log in as `theirlogin#adminlogin` with their own valid password and be switched into the admin's session, provided the admin account has a `userdivisions` row.
- Confirmed in a controlled test against a live instance using a low-privilege test account.

## Fix
Scope the `full_access` check to the authenticating login (`$login`) instead of an existence check against the whole `users` table.

## Test plan
- [x] `php -l lib/Auth.class.php` passes
- [x] Reproduced escalation on unpatched code with a limited-rights test account switching into an admin login
- [x] Confirmed blocked after patch (same test account, same target login, no longer switches)